### PR TITLE
Made email able to be validated as a proper email

### DIFF
--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -67,9 +67,8 @@ export default {
       phonetype: ["Cell", "Landline", "Other"],
       radios: "May we contact you for a follow up vaccination?",
       emailRules: [
-        (v) => !!v || "E-mail is required",
         (v) =>
-          /.+@.+\..+/.test(v) ||
+          /^[\s]*$|.+@.+\..+/.test(v) ||
           "E-mail must be in the format example@example.com",
       ],
     };

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -1,118 +1,78 @@
 
 <template>
-	<v-container fluid>
-	
-			<v-row>
-		<v-col
-        cols="12"
-        sm="6"
-        md="3">
-			<v-text-field
-			:rules="['Required']"
-            label="Primary Phone Number"
-			placeholder="###-###-####"
-			></v-text-field>
-        </v-col>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12" sm="6" md="3">
+        <v-text-field
+          :rules="['Required']"
+          label="Primary Phone Number"
+          placeholder="###-###-####"
+        ></v-text-field>
+      </v-col>
 
-        <v-col
-          class="d-flex" 
-				cols="6" 
-				sm="2">
-							
-				<v-select
-					:rules="['Required']"
-					v-model="e7"
-                    :items="phonetype"
-                    label="Phone Type"
-				></v-select>
-        </v-col>
-		
-	
-</v-row>
+      <v-col class="d-flex" cols="6" sm="2">
+        <v-select
+          :rules="['Required']"
+          v-model="e7"
+          :items="phonetype"
+          label="Phone Type"
+        ></v-select>
+      </v-col>
+    </v-row>
 
-<v-row>
+    <v-row>
+      <v-col cols="6" sm="6" md="3">
+        <v-checkbox
+          v-model="checkbox"
+          label="I have no phone number"
+        ></v-checkbox>
+      </v-col>
+    </v-row>
 
-		<v-col
-			cols="6"
-			sm="6"
-			md="3"
-		>
-		
-		<v-checkbox
-			v-model="checkbox"
-			label="I have no phone number"
-		></v-checkbox>
-		</v-col>
+    <v-row>
+      <v-col cols="12" sm="6" md="6">
+        <v-text-field
+          :rules="emailRules"
+          label="Primary Email Address"
+          placeholder="johnsmith@email.com"
+        ></v-text-field>
+      </v-col>
+    </v-row>
+    <v-col cols="12" sm="6" md="3">
+      <v-checkbox
+        v-model="checkbox"
+        label="I have no email address"
+      ></v-checkbox>
+    </v-col>
 
-</v-row>
-
-<v-row>
-		<v-col
-        cols="12"
-        sm="6"
-        md="6">
-			<v-text-field
-			:rules="['Required']"
-            label="Primary Email Address"
-			placeholder="johnsmith@email.com"
-			></v-text-field>
-        </v-col>
-
-		
-
-
-</v-row>
-		<v-col
-			cols="12"
-			sm="6"
-			md="3"
-		>
-		
-		<v-checkbox
-			v-model="checkbox"
-			label="I have no email address"
-		></v-checkbox>
-		</v-col>
-
-
-
-<v-row>
-	<v-radio-group
+    <v-row>
+      <v-radio-group
         v-model="test"
-		label="May we contact you regarding follow up vaccination information?"
+        label="May we contact you regarding follow up vaccination information?"
       >
-		<v-col
-			align="right"
-			cols="3"
-			sm="3"
-			md="3"
-		>
-        <v-radio
-          label="Yes"
-          value="yes"
-        ></v-radio>
-        <v-radio
-          label="No"
-          value="no"
-        ></v-radio>
-		</v-col>
+        <v-col align="right" cols="3" sm="3" md="3">
+          <v-radio label="Yes" value="yes"></v-radio>
+          <v-radio label="No" value="no"></v-radio>
+        </v-col>
       </v-radio-group>
-	
-</v-row>
-
-</v-container>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
-
-  export default {
-    name: 'SinglePatientContactInfo',
-	data () {
-		return { 
-			phonetype:['Cell', 'Landline', 'Other'],
-			radios: 'May we contact you for a follow up vaccination?'
-		}
-		
-	},
-  }
+export default {
+  name: "SinglePatientContactInfo",
+  data() {
+    return {
+      phonetype: ["Cell", "Landline", "Other"],
+      radios: "May we contact you for a follow up vaccination?",
+      emailRules: [
+        (v) => !!v || "E-mail is required",
+        (v) =>
+          /.+@.+\..+/.test(v) ||
+          "E-mail must be in the format example@example.com",
+      ],
+    };
+  },
+};
 </script>


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-258

## :newspaper: [Work Description]
Made email able to be validated as a proper email. 
Example email is shown to the user to give them a guide on how to write the email.
Email field will also validate if left blank, allowing users to complete the form if they do not have an email.

The general code was reformatted for clarity.

## :vertical_traffic_light: [Testing/QA Notes]
Ran the project and tested on Firefox.
