### PR TITLE
[MVS-327] swap header bar with progress bar

### DIFF
--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-app id="Patient-registration"> 
+  <v-app id="Patient-registration" style="background: #757575"> 
     <v-main>
 		<v-container>
-			<v-card class="elevation-12" min-width="400" max-width="1000"> 
+			<v-card flat> 
 				<v-stepper v-model="page">	
 					<!-- v-stepper-header is the progress bar along the top of the page -->
-					<v-stepper-header>
+					<v-stepper-header flat>
 						<template v-for="n in getNumberOfSteps()">
 							<v-stepper-step
 								:key="`${n}-step`"
@@ -22,7 +22,7 @@
 						</template>
 					</v-stepper-header>
 					
-					<v-toolbar color="primary" dark>
+					<v-toolbar flat color="primary" dark>
 						<!-- We could make the following toolbar dynamic, but for now I just have one title (defined at the end of this file)-->
 						<v-toolbar-title>{{title}}</v-toolbar-title>
 					</v-toolbar>			

--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -4,8 +4,13 @@
 		<v-container>
 			<v-card flat> 
 				<v-stepper v-model="page" class="elevation-0">	
+					<v-toolbar flat color="primary" dark>
+						<!-- We could make the following toolbar dynamic, but for now I just have one title (defined at the end of this file)-->
+						<v-toolbar-title>{{title}}</v-toolbar-title>
+					</v-toolbar>
+
 					<!-- v-stepper-header is the progress bar along the top of the page -->
-					<v-stepper-header flat>
+					<v-stepper-header class="elevation-0">
 						<template v-for="n in getNumberOfSteps()">
 							<v-stepper-step
 								:key="`${n}-step`"
@@ -21,11 +26,6 @@
 							></v-divider>
 						</template>
 					</v-stepper-header>
-					
-					<v-toolbar flat color="primary" dark>
-						<!-- We could make the following toolbar dynamic, but for now I just have one title (defined at the end of this file)-->
-						<v-toolbar-title>{{title}}</v-toolbar-title>
-					</v-toolbar>			
 					
 					<!--The v-stepper-items holds all of the "page" content we will swap in an out based on the navigation-->
 					<v-stepper-items>

--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -1,9 +1,9 @@
 <template>
-  <v-app id="Patient-registration" style="background: #757575"> 
+  <v-app id="Patient-registration"> <!--style="background: #F5F5F5"--> 
     <v-main>
 		<v-container>
 			<v-card flat> 
-				<v-stepper v-model="page">	
+				<v-stepper v-model="page" class="elevation-0">	
 					<!-- v-stepper-header is the progress bar along the top of the page -->
 					<v-stepper-header flat>
 						<template v-for="n in getNumberOfSteps()">


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-327

## :newspaper: [Work Description]
Swapped the order of v-toolbar and v-stepper-header in App.vue

## :vertical_traffic_light: [Testing/QA Notes]
Built and ran the application in my local browser (Chrome).  Verified that the page title bar and progress bar have been swapped.
