### PR TITLE
Mvs 256 validate zip code field in single patient home address.vue page

### DIFF
--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -57,7 +57,7 @@
 					required
 					:rules="[v => !!v || 'Zipcode field is required']"
 					label="Zipcode"
-					v-model="postalCode"
+					v-model="postalCode"					
 				></v-text-field>
 			</v-col>
 		</v-row>	
@@ -101,9 +101,30 @@ import EventBus from '../eventBus'
 			stateAddress: '',
 			countryAddress: '',
 			postalCode: ''
-		}
-		
+		}				
 	},
+	
+	rules1: {
+        postalCode: [{
+          required: true,
+          message: 'Please enter Mobile Number',
+          trigger: 'blur'
+        }, {
+          min: 10,
+          max: 10,
+          message: 'Length must be 10',
+          trigger: 'blur'
+        }, {
+          pattern: /^\d*$/,
+          message: 'Must be all numbers',
+          trigger: 'blur'
+        }, {
+          pattern: /^[789]/,
+          message: 'Must start 7, 8 or 9',
+          trigger: 'blur'
+        }]
+      },
+	
 	methods: {
 		sendHomeAddressInfoToReviewPage()
 		{
@@ -158,6 +179,8 @@ import EventBus from '../eventBus'
 				message += " *zipcode"
 				valid = false
 			}
+			
+	
 
 			if (valid == false) {
 				alert(message)

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -55,7 +55,7 @@
 				<v-text-field
 					id = "zipcode"
 					required
-					:rules="[v => !!v || 'Zipcode field is required']"
+					:rules="postalCodeRules"
 					label="Zipcode"
 					v-model="postalCode"					
 				></v-text-field>

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -78,6 +78,13 @@ import EventBus from '../eventBus'
   export default {
 	data () {
 		return {
+			postalCodeRules: [
+        (v) => !!v || "Zip code is required",
+			(v) =>
+			/(^\d{5}$)|(^\d{5}-\d{4}$)/.test(v) ||
+          "Zip code must be in format of ##### or #####-####",
+      ],
+			
 			state:[
 		'Alabama', 'Alaska', 'American Samoa', 'Arizona',
 		'Arkansas', 'California', 'Colorado', 'Connecticut',


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-256

## :newspaper: [Work Description]
Updated Single Patient Home Address page so that user can only enter a valid zip code either in the format ##### or #####-####

## :vertical_traffic_light: [Testing/QA Notes]
Ran the application on the local drive
Single patient registration then navigate to Home Address page and enter information
Zip code field shows if entry is incorrect with numbers, symbols, or letters
Zip code field should only allow entry that has format ##### or #####-####