### PR TITLE
[MVS-331] Anchor and adjust line spacing so information doesn't pop up across entire screen

### DIFF
--- a/PatientRegistrationApp/src/components/GreetingPage.vue
+++ b/PatientRegistrationApp/src/components/GreetingPage.vue
@@ -38,8 +38,6 @@
 					color="primary"
 					group
 				>
-					<v-tooltip top>
-						<template v-slot:activator="{on, attrs}">
 							<v-btn 
 									class="ma-2"
 									outlined 
@@ -52,9 +50,7 @@
 									<v-icon left color="secondary">mdi-account</v-icon>
 									Register myself
 							</v-btn>
-						</template>
-						<span>Register yourself!</span>
-					</v-tooltip>
+
 					<v-tooltip right :nudge-bottom='130' max-width="20%">
 						<template v-slot:activator="{on, attrs}">
 							<v-btn 

--- a/PatientRegistrationApp/src/components/GreetingPage.vue
+++ b/PatientRegistrationApp/src/components/GreetingPage.vue
@@ -55,7 +55,7 @@
 						</template>
 						<span>Register yourself!</span>
 					</v-tooltip>
-					<v-tooltip top>
+					<v-tooltip right :nudge-bottom='130' max-width="20%">
 						<template v-slot:activator="{on, attrs}">
 							<v-btn 
 									class="ma-2"

--- a/PatientRegistrationApp/src/components/GreetingPage.vue
+++ b/PatientRegistrationApp/src/components/GreetingPage.vue
@@ -51,7 +51,7 @@
 									Register myself
 							</v-btn>
 
-					<v-tooltip right :nudge-bottom='130' max-width="20%">
+					<v-tooltip bottom max-width="20%">
 						<template v-slot:activator="{on, attrs}">
 							<v-btn 
 									class="ma-2"


### PR DESCRIPTION


## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-331

## :newspaper: [Work Description]
Anchor and adjust line spacing so information doesn't pop up across the entire screen in the greeting page

## :vertical_traffic_light: [Testing/QA Notes]
- run the vue app using the local host 
- hover over the household registration and make sure that the tooltip pops up on the right bottom corner of the button 
- make sure that the tooltip doesn't cover the whole screen and that it has a specific width 