### PR TITLE
Added library v-mask for phone validation and easy completion. [MVS-257] & [MVS-259]

### DIFF
--- a/PatientRegistrationApp/package.json
+++ b/PatientRegistrationApp/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "v-mask": "^2.2.3",
     "vue": "^2.6.11",
     "vuetify": "^2.2.11"
   },

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -4,8 +4,10 @@
       <v-col cols="12" sm="6" md="3">
         <v-text-field
           required
-          :rules="[v => !!v || 'Phone number is required']"
+          :rules="[v => v.length === 13 || 'Phone number must be 10 digits' ]"
           label="Phone Number"
+          placeholder="(###)###-####"
+          v-mask="'(###)###-####'"
           v-model="patientPhoneNumber"
         ></v-text-field>
       </v-col>

--- a/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
@@ -28,8 +28,10 @@
       <v-col class="d-flex" cols="5" sm="5">
         <v-text-field
           label="Phone Number"
-			required
-			:rules="[v => !!v || 'Phone number field is required']"
+          required
+          :rules="[v => v.length === 13 || 'Phone number must be 10 digits' ]"
+          placeholder="(###)###-####"
+          v-mask="'(###)###-####'"
           v-model="emergencyContactPhoneNumber"
           prepend-icon="mdi-menu-right"
         ></v-text-field>

--- a/PatientRegistrationApp/src/main.js
+++ b/PatientRegistrationApp/src/main.js
@@ -1,7 +1,9 @@
 import Vue from 'vue'
 import App from './App.vue'
 import vuetify from './plugins/vuetify';
+import VueMask from 'v-mask';
 
+Vue.use(VueMask)
 Vue.config.productionTip = false
 
 new Vue({


### PR DESCRIPTION
Finished validation for emergency contact and single patient.

## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-257

## :newspaper: [Work Description]
In emergency contact info and single patient info, I made it so the phone number is auto formatted when it is input into the field. The field will only take ()'s -'s and numbers. Red text reminds the user to put in all 10 digits of the phone number.

## :vertical_traffic_light: [Testing/QA Notes]
I went to single patient contact info page and single patient emergency contact page to put in a phone number. 
I tried to put letter and was not allowed to, there was a prompt telling me the phone number had to be 10 digits and once I put the full number the prompt went away.
