### PR TITLE
[MVS-387] Autofill country to be USA in Home Address fields

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -98,7 +98,7 @@ import EventBus from '../eventBus'
 			householdCityAddress: '',
 			householdDistrictAddress: '',
 			householdStateAddress: '',
-			householdCountryAddress: '',
+			householdCountryAddress: 'USA',
 			householdPostalCode: ''
 		}
 		

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -105,7 +105,7 @@ import EventBus from '../eventBus'
 			cityAddress: '',
 			districtAddress: '',
 			stateAddress: '',
-			countryAddress: '',
+			countryAddress: 'USA',
 			postalCode: ''
 		}				
 	},


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-387

## :newspaper: [Work Description]
Make USA a default for the country select menu in the HomeAddress page for both Household and single patient registration

## :vertical_traffic_light: [Testing/QA Notes]
- Run the vue app using the localhost 
- Go through the work flow of a single patient and household registration 
- Make sure that the country select menu is set to default (USA) before filling it 