### PR TITLE
[MVS-335] Decrease transparency on Email Address options until verified they have one

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
+++ b/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
@@ -176,7 +176,7 @@ import EventBus from '../eventBus'
     {
 		this.emailAvailable = true
 		this.primaryEmail=""
-		this secondaryEmail=""
+		this.secondaryEmail=""
     },
     EmailNotAvailable()
     {

--- a/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
+++ b/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
@@ -41,6 +41,20 @@
 				></v-checkbox>
 			</v-col>
 		</v-row>
+		
+	<v-row>
+	<v-radio-group
+        required
+        :rules="[v => !!v || 'This field is required']"
+        v-model="emailAvailableRadioButtons"
+	>
+        <v-col align="right" cols="12">
+			<v-radio label="I have an E-mail address" value="yes" @change="EmailAvailable()"></v-radio>
+			<v-radio label="I do not have an E-mail address" value="no" @change="EmailNotAvailable()"></v-radio>
+        </v-col>
+	</v-radio-group>
+    </v-row>
+	
 		<v-row>
 			<v-col cols="12" sm="12" md="6">
 				<v-text-field
@@ -48,6 +62,7 @@
 					:rules="emailRules"
 					label="Primary E-mail Address"
 					v-model="primaryEmail"
+					v-show="emailAvailable"
 					prepend-icon="mdi-menu-right"
 				></v-text-field>
 			</v-col>
@@ -56,15 +71,11 @@
 					:rules="emailRules"
 					label="Secondary E-mail Address"
 					v-model="secondaryEmail"
+					v-show="emailAvailable"
 				></v-text-field>
 			</v-col>
 		</v-row>
-			<v-row><v-col cols="6" sm="6" md="3">
-				<v-checkbox
-					v-model="checkbox"
-					label="I have no email address"
-				></v-checkbox>
-			</v-col></v-row>
+
 		<v-row><v-col cols="12" sm="6" md="6">
 			<v-radio-group
 				required
@@ -102,7 +113,9 @@ import EventBus from '../eventBus'
 			secondaryPhoneNumber: '',
 			secondaryPhoneNumberType: '',
 			secondaryEmail: '',
-			approval: ''
+			approval: '',
+			emailAvailable: true,
+			emailAvailableRadioButtons: 'yes'
 		}
 	},
 	methods: {
@@ -129,6 +142,8 @@ import EventBus from '../eventBus'
 				message += " Primary Phone Number"
 				valid = false
 			}
+		if(this.emailAvailable == "")
+		{
 			if(this.primaryEmail == "") 
 			{
 			if(!valid)
@@ -138,6 +153,7 @@ import EventBus from '../eventBus'
 				message += " Primary E-mail"
 				valid = false
 			}
+		}
 			if(this.approval == "") 
 			{
 			if(!valid)
@@ -155,7 +171,17 @@ import EventBus from '../eventBus'
 		
 			this.sendHouseholdContactInfoInfoToReviewPage();
 			return true;
-		}
-	},
-  }
+		},
+	EmailAvailable()
+    {
+      this.emailAvailable = true
+      this.primaryEmail=""
+    },
+    EmailNotAvailable()
+    {
+      this.emailAvailable = false
+      this.primaryEmail="Not available"
+    },
+  },
+}
 </script>

--- a/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
+++ b/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
@@ -174,13 +174,15 @@ import EventBus from '../eventBus'
 		},
 	EmailAvailable()
     {
-      this.emailAvailable = true
-      this.primaryEmail=""
+		this.emailAvailable = true
+		this.primaryEmail=""
+		this secondaryEmail=""
     },
     EmailNotAvailable()
     {
-      this.emailAvailable = false
-      this.primaryEmail="Not available"
+		this.emailAvailable = false
+		this.primaryEmail="Not available"
+		this.secondaryEmail="Not available"
     },
   },
 }

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -152,7 +152,7 @@ export default {
 	
 		this.sendContactInfoInfoToReviewPage();
 		return true;
-		}
+		},
 	EmailAvailable()
     {
       this.emailAvailable = true

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -33,6 +33,19 @@
 	</v-col>
     </v-row>
 
+	<v-row>
+     <v-radio-group
+        required
+        :rules="[v => !!v || 'This field is required']"
+        v-model="emailAddressAvailable"
+      >
+        <v-col align="right" cols="12">
+          <v-radio label="I have an E-mail address" value="yes" @change="EmailAddressAvailable()"></v-radio>
+          <v-radio label="I do not have an E-mail address" value="no" @change="EmailAddressNotAvailable()"></v-radio>
+        </v-col>
+      </v-radio-group>
+    </v-row>
+	
     <v-row>
 	<v-col cols="12" sm="6" md="6">
         <v-text-field
@@ -40,19 +53,13 @@
 			:rules="emailRules"
 			label="E-mail Address"
 			v-model="patientEmail"
+			v-bind:disabled="emailAddressDisabled"
 			prepend-icon="mdi-menu-right"
         ></v-text-field>
 	</v-col>
     </v-row>
 	
-	<v-row>
-    <v-col cols="6" sm="6" md="3">
-      <v-checkbox
-        v-model="checkbox"
-        label="I have no e-mail address"
-      ></v-checkbox>
-    </v-col></v-row>
-	
+
 
     <v-row><v-col cols="12" sm="6" md="6">
       <v-radio-group
@@ -89,7 +96,9 @@ export default {
       patientPhoneNumber: '',
       patientPhoneNumberType: '',
       patientEmail: '',
-      approval: ''
+      approval: '',
+	EmailAddressDisabled: false,
+	EmailAddressAvailable: 'yes',
     };
   },
   methods: {
@@ -114,6 +123,8 @@ export default {
         message += " Phone Number"
         valid = false
 			}
+	if(!this.emailAddressDisabled)
+		{
 			if(this.patientEmail == "") 
 			{
 			if(!valid)
@@ -123,6 +134,7 @@ export default {
         message += " E-mail"
         valid = false
 			}
+		}
 			if(this.approval == "") 
 			{
 			if(!valid)
@@ -141,6 +153,22 @@ export default {
 		this.sendContactInfoInfoToReviewPage();
 		return true;
 		}
-	},
+	EmailAddressAvailable()
+    {
+		this.emailAddressDisabled = false
+		this.patientEmail=""
+    },
+    EmailAddressNotAvailable()
+    {
+		this.emailAddressDisabled = true
+		this.patientEmail="Not Available"
+    },
+  },
 }
 </script>
+<style lang="css" scoped> 
+
+	.v-input--is-disabled {
+		background-color: #E0E0E0;
+	}
+</style>

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -33,15 +33,15 @@
 	</v-col>
     </v-row>
 
-	<v-row>
+    <v-row>
      <v-radio-group
         required
         :rules="[v => !!v || 'This field is required']"
-        v-model="emailAddressAvailable"
+        v-model="emailAvailableRadioButtons"
       >
         <v-col align="right" cols="12">
-          <v-radio label="I have an E-mail address" value="yes" @change="EmailAddressAvailable()"></v-radio>
-          <v-radio label="I do not have an E-mail address" value="no" @change="EmailAddressNotAvailable()"></v-radio>
+          <v-radio label="I have a phone number" value="yes" @change="EmailAvailable()"></v-radio>
+          <v-radio label="I do not have a phone number" value="no" @change="EmailNotAvailable()"></v-radio>
         </v-col>
       </v-radio-group>
     </v-row>
@@ -53,7 +53,7 @@
 			:rules="emailRules"
 			label="E-mail Address"
 			v-model="patientEmail"
-			v-bind:disabled="emailAddressDisabled"
+			v-show="emailAvailable"
 			prepend-icon="mdi-menu-right"
         ></v-text-field>
 	</v-col>
@@ -97,8 +97,8 @@ export default {
       patientPhoneNumberType: '',
       patientEmail: '',
       approval: '',
-	EmailAddressDisabled: false,
-	EmailAddressAvailable: 'yes',
+		emailAvailable: true,
+		emailAvailableRadioButtons: 'yes'
     };
   },
   methods: {
@@ -123,7 +123,7 @@ export default {
         message += " Phone Number"
         valid = false
 			}
-	if(!this.emailAddressDisabled)
+	if(this.emailAvailable == "")
 		{
 			if(this.patientEmail == "") 
 			{
@@ -153,22 +153,16 @@ export default {
 		this.sendContactInfoInfoToReviewPage();
 		return true;
 		}
-	EmailAddressAvailable()
+	EmailAvailable()
     {
-		this.emailAddressDisabled = false
-		this.patientEmail=""
+      this.emailAvailable = true
+      this.patientEmail=""
     },
-    EmailAddressNotAvailable()
+    EmailNotAvailable()
     {
-		this.emailAddressDisabled = true
-		this.patientEmail="Not Available"
+      this.emailAvailable = false
+      this.patientEmail="Not available"
     },
   },
 }
 </script>
-<style lang="css" scoped> 
-
-	.v-input--is-disabled {
-		background-color: #E0E0E0;
-	}
-</style>

--- a/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientContactInfo.vue
@@ -40,8 +40,8 @@
         v-model="emailAvailableRadioButtons"
       >
         <v-col align="right" cols="12">
-          <v-radio label="I have a phone number" value="yes" @change="EmailAvailable()"></v-radio>
-          <v-radio label="I do not have a phone number" value="no" @change="EmailNotAvailable()"></v-radio>
+          <v-radio label="I have an E-mail address" value="yes" @change="EmailAvailable()"></v-radio>
+          <v-radio label="I do not have an E-mail address" value="no" @change="EmailNotAvailable()"></v-radio>
         </v-col>
       </v-radio-group>
     </v-row>


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-

## :newspaper: [Work Description]
Disable the email address fields when the user picks "I have no email address" 

## :vertical_traffic_light: [Testing/QA Notes]
- Run the vue.app using a local host 
- check the single patient registration contact info page, and switch between "i have an email address" and "I have no email address" 
- Do the same for the household registration Contact Info page 
