### PR TITLE
Mvs 432 validate phone number fields in household vue pages

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
+++ b/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
@@ -23,6 +23,9 @@
 			</v-col>
 			<v-col cols="12" sm="6" md="3">
 				<v-text-field
+					:rules="[v => v.length === 13 || 'Phone number must be 10 digits']"
+					placeholder="(###)###-####"
+					v-mask="'(###)###-####'"
 					label="Secondary Phone Number"
 					v-model="secondaryPhoneNumber"
 				></v-text-field>

--- a/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
+++ b/PatientRegistrationApp/src/components/HouseholdContactInfo.vue
@@ -4,7 +4,9 @@
 			<v-col cols="12" sm="6" md="3">
 				<v-text-field
 					required
-					:rules="[v => !!v || 'Phone number is required']"
+					:rules="[v => v.length === 13 || 'Phone number must be 10 digits']"
+					placeholder="(###)###-####"
+					v-mask="'(###)###-####'"
 					label="Primary Phone Number"
 					v-model="primaryPhoneNumber"
 					prepend-icon="mdi-menu-right"

--- a/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
@@ -29,7 +29,9 @@
         <v-text-field
           label="Phone Number"
           required
-          :rules="[v => !!v || 'Phone number field is required']"
+          :rules="[v => v.length === 13 || 'Phone number must be 10 digits']"
+          placeholder="(###)###-####"
+          v-mask="'(###)###-####'"
           v-model="householdEmergencyContactPhoneNumber"
 			prepend-icon="mdi-menu-right"
         ></v-text-field>


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-432

## :newspaper: [Work Description]
In household emergency contact info and household patient info, the phone number only accepts numbers, dashes '-', and brackets '()' and autoformats the field. Red text reminds the user to put in all 10 digits of the phone number.

## :vertical_traffic_light: [Testing/QA Notes]
_Describe what steps you took to test and verify operation of this update_
Register a household with the required fields. In the household patient info and emergency contact pages, enter a phone number. Ensure that numbers, dashes '-', and brackets '()' are the only valid entries in these fields. The field was tested for numbers, symbols, and letters to ensure the formatting stayed consistent throughout entries.