### PR TITLE
[MVS-333] Hide home address fields when I dont have an address is picked

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -1,5 +1,17 @@
 <template>
 	<v-container fluid>
+	<v-row>
+     <v-radio-group
+        required
+        :rules="[v => !!v || 'This field is required']"
+        v-model="homeAddressAvailableRadioButtons"
+      >
+        <v-col align="right" cols="12">
+          <v-radio label="I have a home address" value="yes" @change="HomeAddressAvailable()"></v-radio>
+          <v-radio label="I do not have a home address" value="no" @change="HomeAddressNotAvailable()"></v-radio>
+        </v-col>
+      </v-radio-group>
+    </v-row>
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
@@ -8,6 +20,7 @@
 					:rules="[v => !!v || 'Address field is required']"
 					label="Home Address"
 					v-model="householdLineAddress"
+					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right"
 				></v-text-field>
 			</v-col>
@@ -20,6 +33,7 @@
 					:rules="[v => !!v || 'City field is required']"
 					label="City"
 					v-model="householdCityAddress"
+					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right"
 				></v-text-field>
 			</v-col>
@@ -29,6 +43,7 @@
 					required
 					:rules="[v => !!v || 'State field is required']"
 					v-model="householdStateAddress"
+					v-show="homeAddressAvailable"
                     :items="state"
                     label="State"
 				></v-select>
@@ -40,6 +55,7 @@
 					:rules="[v => !!v || 'County field is required']"
                     label="County"
 					v-model="householdDistrictAddress"
+					v-show="homeAddressAvailable"
 				></v-text-field>
 			</v-col>
 			<v-col class="d-flex" cols="2" sm="2">
@@ -48,6 +64,7 @@
 					required
 					:rules="[v => !!v || 'Country field is required']"
 					v-model="householdCountryAddress"
+					v-show="homeAddressAvailable"
                     :items="country"
                     label="Country"
 				></v-select>
@@ -59,17 +76,10 @@
 					:rules="[v => !!v || 'Zipcode field is required']"
 					label="Zipcode"
 					v-model="householdPostalCode"
+					v-show="homeAddressAvailable"
 				></v-text-field>
 			</v-col>
 		</v-row>	
-		<v-row align="center" justify="center">
-			<v-col cols="12" sm="6" md="3">
-				<v-checkbox
-					v-model="checkbox"
-					label="I/We have no home address"
-				></v-checkbox>
-			</v-col>	  		
-		</v-row>
 	</v-container>
 </template>
 
@@ -101,7 +111,9 @@ import EventBus from '../eventBus'
 			householdDistrictAddress: '',
 			householdStateAddress: '',
 			householdCountryAddress: 'USA',
-			householdPostalCode: ''
+			householdPostalCode: '',
+			homeAddressAvailable: true,
+			homeAddressAvailableRadioButtons: 'yes'
 		}
 		
 	},
@@ -124,7 +136,8 @@ import EventBus from '../eventBus'
 			var valid = true
 			var message = "Woops! You need to enter the following field(s):"
 			
-			
+		if(this.homeAddressAvailable)
+		{	
 			if(this.householdLineAddress == "") 
 			{
 				message += " Address"
@@ -185,7 +198,7 @@ import EventBus from '../eventBus'
 				message += " Zipcode"
 				valid = false
 			}
-
+		}
 			if (valid == false) 
 			{
 				alert(message)
@@ -194,7 +207,27 @@ import EventBus from '../eventBus'
 			
 			this.sendHouseholdHomeAddressInfoToReviewPage();
 			return true;
-		}
+		},
+	HomeAddressAvailable()
+    {
+	this.homeAddressAvailable = true
+	this.householdlineAddress=""
+	this.householdcityAddress=""
+	this.householdstateAddress=""
+	this.householddistrictAddress=""
+	this.householdcountryAddress=""
+	this.householdpostalCode=""
+    },
+    HomeAddressNotAvailable()
+    {
+	this.homeAddressAvailable = false
+	this.householdlineAddress="Not Available"
+	this.householdcityAddress="Not Available"
+	this.householdstateAddress="Not Available"
+	this.householddistrictAddress="Not Available"
+	this.householdcountryAddress="Not Available"
+	this.householdpostalCode="Not Available"
+    },
 	},
-  }
+}
 </script>

--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -211,22 +211,20 @@ import EventBus from '../eventBus'
 	HomeAddressAvailable()
     {
 	this.homeAddressAvailable = true
-	this.householdlineAddress=""
-	this.householdcityAddress=""
-	this.householdstateAddress=""
-	this.householddistrictAddress=""
-	this.householdcountryAddress=""
-	this.householdpostalCode=""
+	this.householdLineAddress=""
+	this.householdCityAddress=""
+	this.householdStateAddress=""
+	this.householdDistrictAddress=""
+	this.householdPostalCode=""
     },
     HomeAddressNotAvailable()
     {
 	this.homeAddressAvailable = false
-	this.householdlineAddress="Not Available"
-	this.householdcityAddress="Not Available"
-	this.householdstateAddress="Not Available"
-	this.householddistrictAddress="Not Available"
-	this.householdcountryAddress="Not Available"
-	this.householdpostalCode="Not Available"
+	this.householdLineAddress="Not Available"
+	this.householdCityAddress="Not Available"
+	this.householdStateAddress="Not Available"
+	this.householdDistrictAddress="Not Available"
+	this.householdPostalCode="Not Available"
     },
 	},
 }

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -245,7 +245,6 @@ import EventBus from '../eventBus'
 	this.cityAddress=""
 	this.stateAddress=""
 	this.districtAddress=""
-	this.countryAddress=""
 	this.postalCode=""
     },
     HomeAddressNotAvailable()
@@ -255,7 +254,6 @@ import EventBus from '../eventBus'
 	this.cityAddress="Not Available"
 	this.stateAddress="Not Available"
 	this.districtAddress="Not Available"
-	this.countryAddress="Not Available"
 	this.postalCode="Not Available"
     },
 	},

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -1,5 +1,17 @@
 <template>
 	<v-container fluid>
+	<v-row>
+     <v-radio-group
+        required
+        :rules="[v => !!v || 'This field is required']"
+        v-model="homeAddressAvailableRadioButtons"
+      >
+        <v-col align="right" cols="12">
+          <v-radio label="I have a home address" value="yes" @change="HomeAddressAvailable()"></v-radio>
+          <v-radio label="I do not have a home address" value="no" @change="HomeAddressNotAvailable()"></v-radio>
+        </v-col>
+      </v-radio-group>
+    </v-row>
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
@@ -8,6 +20,7 @@
 					:rules="[v => !!v || 'Address field is required']"
 					label="Home Address"
 					v-model="lineAddress"
+					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right"
 				></v-text-field>
 			</v-col>
@@ -20,6 +33,7 @@
 					:rules="[v => !!v || 'City field is required']"
 					label="City"
 					v-model="cityAddress"
+					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right"
 				></v-text-field>
 			</v-col>
@@ -29,6 +43,7 @@
 					required
 					:rules="[v => !!v || 'State field is required']"
 					v-model="stateAddress"
+					v-show="homeAddressAvailable"
                     :items="state"
                     label="State"
 				></v-select>
@@ -40,6 +55,7 @@
 					:rules="[v => !!v || 'County field is required']"
                     label="County"
 					v-model="districtAddress"
+					v-show="homeAddressAvailable"
 				></v-text-field>
 			</v-col>
 			<v-col class="d-flex" cols="2" sm="2">
@@ -48,6 +64,7 @@
 					required
 					:rules="[v => !!v || 'Country field is required']"
 					v-model="countryAddress"
+					v-show="homeAddressAvailable"
                     :items="country"
                     label="Country"
 				></v-select>
@@ -58,18 +75,11 @@
 					required
 					:rules="postalCodeRules"
 					label="Zipcode"
-					v-model="postalCode"					
+					v-model="postalCode"
+					v-show="homeAddressAvailable"					
 				></v-text-field>
 			</v-col>
 		</v-row>	
-		<v-row align="center" justify="center">
-			<v-col cols="12" sm="6" md="3">
-				<v-checkbox
-					v-model="checkbox"
-					label="I have no home address"
-				></v-checkbox>
-			</v-col>	  		
-		</v-row>
 	</v-container>
 </template>
 
@@ -108,7 +118,9 @@ import EventBus from '../eventBus'
 			districtAddress: '',
 			stateAddress: '',
 			countryAddress: 'USA',
-			postalCode: ''
+			postalCode: '',
+			homeAddressAvailable: true,
+			homeAddressAvailableRadioButtons: 'yes'
 		}				
 	},
 	
@@ -152,7 +164,8 @@ import EventBus from '../eventBus'
 			var valid = true
 			var message = "Woops! You need to enter the following field(s):"
 			
-			
+		if(this.homeAddressAvailable)
+		{	
 			if(this.lineAddress == "") 
 			{
 				message += " Address"
@@ -214,7 +227,7 @@ import EventBus from '../eventBus'
 				valid = false
 			}
 			
-	
+		}
 
 			if (valid == false) 
 			{
@@ -224,7 +237,27 @@ import EventBus from '../eventBus'
 			
 			this.sendHomeAddressInfoToReviewPage();
 			return true;
-		}
+		},
+	HomeAddressAvailable()
+    {
+	this.homeAddressAvailable = true
+	this.lineAddress=""
+	this.cityAddress=""
+	this.stateAddress=""
+	this.districtAddress=""
+	this.countryAddress=""
+	this.postalCode=""
+    },
+    HomeAddressNotAvailable()
+    {
+	this.homeAddressAvailable = false
+	this.lineAddress="Not Available"
+	this.cityAddress="Not Available"
+	this.stateAddress="Not Available"
+	this.districtAddress="Not Available"
+	this.countryAddress="Not Available"
+	this.postalCode="Not Available"
+    },
 	},
 }
 </script>


### PR DESCRIPTION
…ked in single patient registration

## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-333

## :newspaper: [Work Description]
Add radio buttons to the home address page. Then make sure that when the user picks I dont have an address, the address fields are hidden, and the user can proceed 

## :vertical_traffic_light: [Testing/QA Notes]
- Run the patient registration app locally 
- Go to the Home Address page 
- Make sure that when "I dont have a home address" radio button is picked, the text fields are hidden 