### PR TITLE
Mvs 423 format vaccination screening component.vue component

### DIFF
--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -109,21 +109,18 @@
           <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
+
           <v-row align="center" justify="center">
-            <v-col cols="2">
-                <v-radio
-                  v-model="vaccinationYes"
-                  label="Yes"
-                  value="Yes"
-                ></v-radio>
-            </v-col>
-            <v-col cols="2">   
-                <v-radio
-                  v-model="vaccinationNo"
-                  label="No"
-                  value="No"
-                ></v-radio>
-            </v-col>
+            <v-radio-group v-model="vaccinationProceed" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
           </v-row>
         </v-card>
       </v-col>
@@ -141,6 +138,10 @@
     name: 'VaccinationScreeningComponent',
     methods: 
     {
+      vaccinationSelected()
+      {
+        alert('selected')
+      }
     },
     components: 
     {

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -105,24 +105,23 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark height="50%" v-show="screeningComplete">
-          <v-card-title class="headline justify-center">
-              Proceed with vaccination?
-          </v-card-title>
-
-          <v-row align="center" justify="center">
-            <v-radio-group v-model="vaccinationProceed" row>
-                  <v-radio
-                    label="Yes"
-                    value="Yes"
-                  ></v-radio>
-                  <v-radio
-                    label="No"
-                    value="No"
-                  ></v-radio>
-              </v-radio-group>
-          </v-row>
-        </v-card>
+          <v-card class="mx-auto my-12" color="accent" dark height="50%" v-show="screeningComplete">
+            <v-card-title class="headline justify-center">
+                Proceed with vaccination?
+            </v-card-title>
+            <v-row align="center" justify="center">
+              <v-radio-group v-model="vaccinationProceed" row>
+                    <v-radio
+                      label="Yes"
+                      value="Yes"
+                    ></v-radio>
+                    <v-radio
+                      label="No"
+                      value="No"
+                    ></v-radio>
+                </v-radio-group>
+            </v-row>
+          </v-card>
       </v-col>
     </v-row>
     <v-row>

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -14,7 +14,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="patientInfoComfirmed" row>
+              <v-radio-group v-model="patientInfoComfirmed" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -39,7 +39,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="consentFormSigned" row>
+              <v-radio-group v-model="consentFormSigned" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -64,7 +64,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="screeningCompleted" row>
+              <v-radio-group v-model="screeningCompleted" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -89,7 +89,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="factSheetProvided" row>
+              <v-radio-group v-model="factSheetProvided" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -105,7 +105,7 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark height="50%" v-show="true">
+        <v-card color="accent" dark height="50%" v-show="screeningComplete">
           <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
@@ -134,20 +134,33 @@
 </template>
 
 <script>
+
   export default {
     name: 'VaccinationScreeningComponent',
     methods: 
     {
-      vaccinationSelected()
-      {
-        alert('selected')
-      }
+     screeningChecklistUpdate()
+     {
+       if(this.isScreeningChecklistComplete())
+       {
+         this.screeningComplete = true
+       }
+       else
+       {
+         this.screeningComplete = false
+       }
+     },
+     isScreeningChecklistComplete()
+     {
+       return (this.patientInfoComfirmed && this.consentFormSigned && this.screeningCompleted && this.factSheetProvided); 
+     }
     },
     components: 
     {
     },
     data () {
       return {
+        screeningComplete: false
       }
     }
   }

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-container>
-    <v-row>
+  <v-container fill-height fluid>
+    <v-row no-gutters>
       <v-col cols="6">
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Patient info confirmed? </div>
@@ -13,7 +13,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="patientInfoComfirmed" row>
                   <v-radio
                     label="Yes"
@@ -27,9 +27,9 @@
             </v-row>
           </v-col>
         </v-row> 
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Consent form signed?</div>
@@ -38,7 +38,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="consentFormSigned" row>
                   <v-radio
                     label="Yes"
@@ -52,9 +52,9 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Proper screening completed?</div>
@@ -63,7 +63,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="screeningCompleted" row>
                   <v-radio
                     label="Yes"
@@ -77,9 +77,9 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>VIS fact sheet provided?</div>
@@ -88,7 +88,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="factSheetProvided" row>
                   <v-radio
                     label="Yes"
@@ -105,22 +105,24 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark>
-          <v-card-title style="center" class="headline">
+        <v-card color="accent" dark height="50%" v-show="true">
+          <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
           <v-row align="center" justify="center">
-            <v-col cols="12">
-              <v-radio-group v-model="row" row>
+            <v-col cols="2">
                 <v-radio
+                  v-model="vaccinationYes"
                   label="Yes"
                   value="Yes"
                 ></v-radio>
+            </v-col>
+            <v-col cols="2">   
                 <v-radio
+                  v-model="vaccinationNo"
                   label="No"
                   value="No"
                 ></v-radio>
-              </v-radio-group>
             </v-col>
           </v-row>
         </v-card>

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -3,66 +3,107 @@
     <v-row>
       <v-col cols="6">
         <v-row>
-          <v-radio-group v-model="patientInfoComfirmed" row>
-            <template v-slot:label>
-              <div>Patient info confirmed? </div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Patient info confirmed? </div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="patientInfoComfirmed" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+        </v-row> 
+        <v-row>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Consent form signed?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="consentFormSigned" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
         <v-row>
-          <v-radio-group v-model="consentFormSigned" row>
-            <template v-slot:label>
-              <div>Consent form signed?<v-spacer></v-spacer></div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Proper screening completed?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="screeningCompleted" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
         <v-row>
-          <v-radio-group v-model="screeningCompleted" row>
-            <template v-slot:label>
-              <div>Proper screening completed?</div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
-        </v-row>
-        <v-row>
-          <v-radio-group v-model="factSheetProvided" row>
-            <template v-slot:label>
-              <div>VIS fact sheet provided?</div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>VIS fact sheet provided?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="factSheetProvided" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
       </v-col>
+                
       <v-col cols="6">
         <v-card color="accent" dark>
           <v-card-title style="center" class="headline">


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-423

## :newspaper: [Work Description]
Updated VaccinationScreeningComponent.vue to match the formatting of the associated wireframe.
Made the "Proceed with vaccination?" box only visible once the screening checklist has been completed.

## :vertical_traffic_light: [Testing/QA Notes]
- Build and load the application; verify that there are no build errors
- Navigate to the "Vaccination Event" left menu option
- Verify that the screening checklist (4 items) is presented with an associated set of Yes/No radio buttons
- Verify that unless/until the screening checklist is completed (with either Yes or No responses), the "Proceed with vaccination?" box (and associated radio buttons) are not visible.
