### PR TITLE
MVS 389 Restrict DOB Dates

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -45,30 +45,29 @@
       <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-          ref="householdMenu"
-          v-model="householdMenu"
+          attach
           :close-on-content-click="false"
           transition="scale-transition"
           offset-y
           min-width="290px"
         >
-          <template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on }">
             <v-text-field
               v-model="householdDate"
               label="Date of Birth"
+              :rules="birthdateRules"
+              placeholder="YYYY-MM-DD"
+              v-mask="'####-##-##'"
               prepend-icon="mdi-calendar"
-              readonly
-              v-bind="attrs"
-              v-on="on"
+              @click:prepend="on.click"
             ></v-text-field>
           </template>
 
           <v-date-picker
-            ref="picker"
+            reactive
             v-model="householdDate"
-            min="1900-01-01"
+            :min="minDateStr"
             :max="maxDateStr"
-            @change="save"
           ></v-date-picker>
         </v-menu>
       </v-col>
@@ -158,15 +157,28 @@ export default {
       householdFamilyName: "",
       householdGivenName: "",
       householdSuffix: "",
-      householdBirthDate: "",
+      householdDate: "",
       householdGender: "",
       householdPatientPhoto: "",
       householdRaceSelections: "",
       householdEthnicitySelection: "",
       preferredLanguage: "",
+      minDateStr: "1900-01-01",
+      birthdateRules: [
+        (v) => !!v || "DOB is required",
+        (v) => v.length == 10 || "DOB must be in specified format",
+        (v) => this.validBirthdate(v) || "Invalid DOB",
+      ],
     };
   },
   methods: {
+    validBirthdate(birthdate) {
+      var minDate = Date.parse(this.minDateStr);
+      var maxDate = Date.parse(this.maxDateStr);
+      var date = Date.parse(birthdate);
+
+      return !Number.isNaN(date) && minDate <= date && date <= maxDate;
+    },
     sendHouseholdPersonalInfoDataToReviewPage() {
       const householdPersonalInfoPayload = {
         householdFamilyName: this.householdFamilyName,
@@ -188,6 +200,8 @@ export default {
       if (this.checkbox) {
         //all household members have the same last name
         EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", this.householdFamilyName);
+      } else {
+        EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", "");
       }
     },
     verifyFormContents() {

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -66,8 +66,8 @@
           <v-date-picker
             ref="picker"
             v-model="householdDate"
-            :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
+            :max="maxDateStr"
             @change="save"
           ></v-date-picker>
         </v-menu>
@@ -231,6 +231,18 @@ export default {
 
       this.sendHouseholdPersonalInfoDataToReviewPage();
       return true;
+    },
+  },
+  computed: {
+    maxDateStr: function() {
+      let d = new Date();
+      let date = [
+        d.getFullYear(),
+        ("0" + (d.getMonth() + 1)).slice(-2),
+        ("0" + d.getDate()).slice(-2),
+      ].join("-");
+
+      return date;
     },
   },
   mounted() {

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -1,144 +1,142 @@
 <template>
-	<v-container fluid>
-	<v-row align="center" justify="center">
-		<!-- Last name -->
-		<v-col class="d-flex" cols="5" sm="5">
-        <v-text-field 
-          label="Last Name" 
-          id="lastName" 
+  <v-container fluid>
+    <v-row align="center" justify="center">
+      <!-- Last name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="Last Name"
+          id="lastName"
           required
-          :rules="[v => !!v || 'Last name field is required']"
+          :rules="[(v) => !!v || 'Last name field is required']"
           v-model="householdFamilyName"
-			prepend-icon="mdi-menu-right"
+          prepend-icon="mdi-menu-right"
         ></v-text-field>
-		</v-col>
+      </v-col>
 
-		<!-- First name -->
-		<v-col class="d-flex" cols="5" sm="5">
-        <v-text-field 
-			label="First Name" 
-			id="firstName" 
-			required
-			:rules="[v => !!v || 'First name field is required']"
-			v-model="householdGivenName">
+      <!-- First name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="First Name"
+          id="firstName"
+          required
+          :rules="[(v) => !!v || 'First name field is required']"
+          v-model="householdGivenName"
+        >
         </v-text-field>
-		</v-col>
+      </v-col>
 
-		<!-- Suffix -->
-		<v-col class="d-flex" cols="2" sm="2">
-        <v-text-field 
-			label="Suffix" 
-			id="suffix" 
-			v-model="householdSuffix">
+      <!-- Suffix -->
+      <v-col class="d-flex" cols="2" sm="2">
+        <v-text-field label="Suffix" id="suffix" v-model="householdSuffix">
         </v-text-field>
-		</v-col>
-	</v-row>
+      </v-col>
+    </v-row>
 
     <v-row>
-		<v-col cols="12" sm="12" md="12">
+      <v-col cols="12" sm="12" md="12">
         <v-checkbox
-			v-model="checkbox"
-			label="All household members have the same last name"
+          v-model="checkbox"
+          label="All household members have the same last name"
         ></v-checkbox>
-		</v-col>
+      </v-col>
     </v-row>
-	
+
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-			ref="householdMenu"
-			v-model="householdMenu"
-			:close-on-content-click="false"
-			transition="scale-transition"
-			offset-y
-			min-width="290px"
+          ref="householdMenu"
+          v-model="householdMenu"
+          :close-on-content-click="false"
+          transition="scale-transition"
+          offset-y
+          min-width="290px"
         >
-		<template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
-				v-model="householdDate"
-				label="Date of Birth"
-				prepend-icon="mdi-calendar"
-				readonly
-				v-bind="attrs"
-				v-on="on"
+              v-model="householdDate"
+              label="Date of Birth"
+              prepend-icon="mdi-calendar"
+              readonly
+              v-bind="attrs"
+              v-on="on"
             ></v-text-field>
-		</template>
+          </template>
 
-		<v-date-picker
+          <v-date-picker
             ref="picker"
             v-model="householdDate"
             :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
             @change="save"
-		></v-date-picker>
+          ></v-date-picker>
         </v-menu>
-		</v-col>
+      </v-col>
 
-		<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Gender identity -->
         <v-select
           :items="genderID"
           label="Gender identity"
           required
-          :rules="[v => !!v || 'Gender identity field is required']"
+          :rules="[(v) => !!v || 'Gender identity field is required']"
           v-model="householdGender"
-			prepend-icon="mdi-menu-right"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-	</v-col>
+      </v-col>
 
-		<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="left" justify="left">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Current Photo -->
         <v-file-input
-			:rules="rules"
-			accept="image/png, image/jpeg, image/bmp"
-			placeholder="Upload a recent photo"
-			v-model="householdPatientPhoto"
-			label="Photo"
-			prepend-icon="mdi-camera"
+          :rules="rules"
+          accept="image/png, image/jpeg, image/bmp"
+          placeholder="Upload a recent photo"
+          v-model="householdPatientPhoto"
+          label="Photo"
+          prepend-icon="mdi-camera"
         ></v-file-input>
-		</v-col>
+      </v-col>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Race -->
         <v-select
           v-model="householdRaceSelections"
           :items="race"
           label="Race (select all that apply)"
-			prepend-icon="mdi-menu-right"
+          prepend-icon="mdi-menu-right"
           multiple
         ></v-select>
-		</v-col>
-		<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Ethnicity -->
         <v-select
           v-model="householdEthnicitySelection"
           :items="ethnicity"
           label="Ethnicity"
-			prepend-icon="mdi-menu-right"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-		</v-col>
-		<v-spacer></v-spacer>
-	</v-row>
-	</v-container>
+      </v-col>
+      <v-spacer></v-spacer>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
-import EventBus from '../eventBus'
+import EventBus from "../eventBus";
 
 export default {
   data() {
@@ -157,20 +155,19 @@ export default {
         "Not Hispanic or Latino",
         "Unknown or prefer not to answer",
       ],
-      householdFamilyName: '',
-      householdGivenName: '',
-      householdSuffix: '',
-      householdBirthDate: '',
-      householdGender: '',
-      householdPatientPhoto: '',
-      householdRaceSelections: '',
-      householdEthnicitySelection: '',
-      preferredLanguage: ''
+      householdFamilyName: "",
+      householdGivenName: "",
+      householdSuffix: "",
+      householdBirthDate: "",
+      householdGender: "",
+      householdPatientPhoto: "",
+      householdRaceSelections: "",
+      householdEthnicitySelection: "",
+      preferredLanguage: "",
     };
   },
   methods: {
-    sendHouseholdPersonalInfoDataToReviewPage()
-    {
+    sendHouseholdPersonalInfoDataToReviewPage() {
       const householdPersonalInfoPayload = {
         householdFamilyName: this.householdFamilyName,
         householdGivenName: this.householdGivenName,
@@ -180,73 +177,66 @@ export default {
         householdPatientPhoto: this.householdPatientPhoto,
         householdRaceSelections: this.householdRaceSelections,
         householdEthnicitySelection: this.householdEthnicitySelection,
-        preferredLanguage: this.preferredLanguage
-      }
-      const householdMemberNumber = 1
-      EventBus.$emit('DATA_HOUSEHOLD_PERSONAL_INFO_PUBLISHED', householdPersonalInfoPayload, householdMemberNumber)
-      if(this.checkbox)
-      {
+        preferredLanguage: this.preferredLanguage,
+      };
+      const householdMemberNumber = 1;
+      EventBus.$emit(
+        "DATA_HOUSEHOLD_PERSONAL_INFO_PUBLISHED",
+        householdPersonalInfoPayload,
+        householdMemberNumber
+      );
+      if (this.checkbox) {
         //all household members have the same last name
-        EventBus.$emit('DATA_HOUSEHOLD_FAMILY_NAME', this.householdFamilyName)
+        EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", this.householdFamilyName);
       }
     },
-    verifyFormContents()
-    {
+    verifyFormContents() {
       //add logic to check form contents
-      var valid = true
-      var message = "Woops! You need to enter the following field(s):"
-      
-      if(this.householdFamilyName == "")  
-	{
-        message += " Last Name"
-        valid = false
-	}
-      
-      if(this.householdGivenName == "") 
-	{
-	if(!valid)
-				{
-				message +=","
-				}
-        message += " First Name"
-        valid = false
-	}
-      
-      
-      if (this.householdDate == null) 
-	{
-	if(!valid)
-				{
-				message +=","
-				}
-        message += " Date of birth"
-        valid = false
-	}
-      
-      if(this.householdGender == "") 
-	{
-	if(!valid)
-				{
-				message +=","
-				}
-        message += " Gender Identity" 
-        valid = false
-	}
-      
-	if (valid == false) 
-		{
-          alert(message)
-          return false
-		}
-      
-        this.sendHouseholdPersonalInfoDataToReviewPage();
-        return true;
-    }
-},
+      var valid = true;
+      var message = "Woops! You need to enter the following field(s):";
+
+      if (this.householdFamilyName == "") {
+        message += " Last Name";
+        valid = false;
+      }
+
+      if (this.householdGivenName == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " First Name";
+        valid = false;
+      }
+
+      if (this.householdDate == null) {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Date of birth";
+        valid = false;
+      }
+
+      if (this.householdGender == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Gender Identity";
+        valid = false;
+      }
+
+      if (valid == false) {
+        alert(message);
+        return false;
+      }
+
+      this.sendHouseholdPersonalInfoDataToReviewPage();
+      return true;
+    },
+  },
   mounted() {
-    EventBus.$on('DATA_LANGUAGE_INFO_PUBLISHED', (preferredLanguage) => {
-			this.preferredLanguage = preferredLanguage;
-		});
-  }
+    EventBus.$on("DATA_LANGUAGE_INFO_PUBLISHED", (preferredLanguage) => {
+      this.preferredLanguage = preferredLanguage;
+    });
+  },
 };
 </script>

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
@@ -72,8 +72,8 @@
           <v-date-picker
             ref="picker"
             v-model="householdDate"
-            :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
+            :max="maxDateStr"
             @change="save"
           ></v-date-picker>
         </v-menu>
@@ -279,6 +279,18 @@ export default {
     },
     setHouseholdFamilyName(householdFamilyName) {
       this.householdFamilyName = householdFamilyName;
+    },
+  },
+  computed: {
+    maxDateStr: function() {
+      let d = new Date();
+      let date = [
+        d.getFullYear(),
+        ("0" + (d.getMonth() + 1)).slice(-2),
+        ("0" + d.getDate()).slice(-2),
+      ].join("-");
+
+      return date;
     },
   },
 };

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
@@ -1,166 +1,162 @@
 <template>
-	<v-container fluid>
+  <v-container fluid>
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5">
-
+      <v-col class="d-flex" cols="5">
         <!-- Language -->
         <v-select
-			:items="languageOptions"
-			label="Preferred language"
-			required
-			:rules="[v => !!v || 'Preferred language field is required']"
-			v-model="preferredLanguage"
-			prepend-icon="mdi-menu-right"
+          :items="languageOptions"
+          label="Preferred language"
+          required
+          :rules="[(v) => !!v || 'Preferred language field is required']"
+          v-model="preferredLanguage"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-	</v-col>
-	<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
-    
+
     <v-row align="center" justify="center">
-      
-	<!-- Last name -->
-	<v-col class="d-flex" cols="5" sm="5">
-        <v-text-field 
-			label="Last Name" 
-			id="lastName" 
-			required
-			:rules="[v => !!v || 'Last name field is required']"
-			v-model="householdFamilyName"
-			prepend-icon="mdi-menu-right"
+      <!-- Last name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="Last Name"
+          id="lastName"
+          required
+          :rules="[(v) => !!v || 'Last name field is required']"
+          v-model="householdFamilyName"
+          prepend-icon="mdi-menu-right"
         ></v-text-field>
-	</v-col>
+      </v-col>
 
-	<!-- First name -->
-	<v-col class="d-flex" cols="5" sm="5">
-        <v-text-field 
-			label="First Name" 
-			id="firstName" 
-			required
-			:rules="[v => !!v || 'First name field is required']"
-			v-model="householdGivenName">
+      <!-- First name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="First Name"
+          id="firstName"
+          required
+          :rules="[(v) => !!v || 'First name field is required']"
+          v-model="householdGivenName"
+        >
         </v-text-field>
-	</v-col>
+      </v-col>
 
-	<!-- Suffix -->
-	<v-col class="d-flex" cols="2" sm="2">
-        <v-text-field 
-			label="Suffix" 
-			id="suffix" 
-			v-model="householdSuffix">
+      <!-- Suffix -->
+      <v-col class="d-flex" cols="2" sm="2">
+        <v-text-field label="Suffix" id="suffix" v-model="householdSuffix">
         </v-text-field>
-	</v-col>
+      </v-col>
     </v-row>
 
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-			ref="householdMenu"
-			v-model="householdMenu"
-			:close-on-content-click="false"
-			transition="scale-transition"
-			offset-y
-			min-width="290px"
+          ref="householdMenu"
+          v-model="householdMenu"
+          :close-on-content-click="false"
+          transition="scale-transition"
+          offset-y
+          min-width="290px"
         >
-		<template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
-				v-model="householdDate"
-				label="Date of Birth"
-				prepend-icon="mdi-calendar"
-				readonly
-				v-bind="attrs"
-				v-on="on"
+              v-model="householdDate"
+              label="Date of Birth"
+              prepend-icon="mdi-calendar"
+              readonly
+              v-bind="attrs"
+              v-on="on"
             ></v-text-field>
-		</template>
+          </template>
 
-		<v-date-picker
+          <v-date-picker
             ref="picker"
             v-model="householdDate"
             :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
             @change="save"
-		></v-date-picker>
+          ></v-date-picker>
         </v-menu>
-	</v-col>
+      </v-col>
 
-	<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Gender identity -->
         <v-select
-			:items="genderID"
-			label="Gender identity"
-			required
-			:rules="[v => !!v || 'Gender identity field is required']"
-			v-model="householdGender"
-			prepend-icon="mdi-menu-right"
+          :items="genderID"
+          label="Gender identity"
+          required
+          :rules="[(v) => !!v || 'Gender identity field is required']"
+          v-model="householdGender"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-	</v-col>
-	<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5">
+      <v-col class="d-flex" cols="5">
         <!-- Relationship -->
         <v-select
-			:items="relationshipOptions"
-			label="Relationship: this person is your"
-			required
-			:rules="[v => !!v || 'Relationship field is required']"
-			v-model="relationship"
-			prepend-icon="mdi-menu-right"
+          :items="relationshipOptions"
+          label="Relationship: this person is your"
+          required
+          :rules="[(v) => !!v || 'Relationship field is required']"
+          v-model="relationship"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-	</v-col>
-	<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="left" justify="left">
-	<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Current Photo -->
         <v-file-input
-			:rules="rules"
-			accept="image/png, image/jpeg, image/bmp"
-			placeholder="Upload a recent photo"
-			v-model="householdPatientPhoto"
-			label="Photo"
-			prepend-icon="mdi-camera"
+          :rules="rules"
+          accept="image/png, image/jpeg, image/bmp"
+          placeholder="Upload a recent photo"
+          v-model="householdPatientPhoto"
+          label="Photo"
+          prepend-icon="mdi-camera"
         ></v-file-input>
-	</v-col>
+      </v-col>
     </v-row>
 
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Race -->
         <v-select
-			v-model="householdRaceSelections"
-			:items="race"
-			label="Race (select all that apply)"
-			prepend-icon="mdi-menu-right"
-			multiple
+          v-model="householdRaceSelections"
+          :items="race"
+          label="Race (select all that apply)"
+          prepend-icon="mdi-menu-right"
+          multiple
         ></v-select>
-	</v-col>
-	<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-	<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Ethnicity -->
         <v-select
-			v-model="householdEthnicitySelection"
-			:items="ethnicity"
-			label="Ethnicity"
-			prepend-icon="mdi-menu-right"
+          v-model="householdEthnicitySelection"
+          :items="ethnicity"
+          label="Ethnicity"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-	</v-col>
-	<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
-	</v-container>
+  </v-container>
 </template>
 
 <script>
-import EventBus from '../eventBus'
+import EventBus from "../eventBus";
 
 export default {
   data() {
@@ -180,28 +176,35 @@ export default {
         "Unknown or prefer not to answer",
       ],
       languageOptions: ["English", "Spanish"],
-      relationshipOptions: ["Child", "Foster Child", "Spouse", "Domestic Partner", "Parent", "In-Law", "Grandparent", "Other Family Member"],
-      householdFamilyName: '',
-      householdGivenName: '',
-      householdSuffix: '',
-      householdBirthDate: '',
-      householdGender: '',
-      householdPatientPhoto: '',
-      householdRaceSelections: '',
-      householdEthnicitySelection: '',
-      preferredLanguage: '',
-      relationship:''
+      relationshipOptions: [
+        "Child",
+        "Foster Child",
+        "Spouse",
+        "Domestic Partner",
+        "Parent",
+        "In-Law",
+        "Grandparent",
+        "Other Family Member",
+      ],
+      householdFamilyName: "",
+      householdGivenName: "",
+      householdSuffix: "",
+      householdBirthDate: "",
+      householdGender: "",
+      householdPatientPhoto: "",
+      householdRaceSelections: "",
+      householdEthnicitySelection: "",
+      preferredLanguage: "",
+      relationship: "",
     };
   },
-  props:
-  {
-    householdMemberNumber: Number
+  props: {
+    householdMemberNumber: Number,
   },
   methods: {
-    sendHouseholdPersonalInfoDataToReviewPage()
-    {
+    sendHouseholdPersonalInfoDataToReviewPage() {
       const householdPersonalInfoPayload = {
-		preferredLanguage: this.preferredLanguage,
+        preferredLanguage: this.preferredLanguage,
         householdFamilyName: this.householdFamilyName,
         householdGivenName: this.householdGivenName,
         householdSuffix: this.householdSuffix,
@@ -209,84 +212,74 @@ export default {
         householdGender: this.householdGender,
         householdPatientPhoto: this.householdPatientPhoto,
         householdRaceSelections: this.householdRaceSelections,
-        householdEthnicitySelection: this.householdEthnicitySelection
+        householdEthnicitySelection: this.householdEthnicitySelection,
+      };
+      EventBus.$emit(
+        "DATA_HOUSEHOLD_PERSONAL_INFO_PUBLISHED",
+        householdPersonalInfoPayload,
+        this.householdMemberNumber
+      );
+    },
+    verifyFormContents() {
+      var valid = true;
+      var message = "Woops! You need to enter the following field(s):";
+
+      if (this.preferredLanguage == "") {
+        message += " Preferred Language";
+        valid = false;
       }
-      EventBus.$emit('DATA_HOUSEHOLD_PERSONAL_INFO_PUBLISHED', householdPersonalInfoPayload, this.householdMemberNumber)
-    },
-    verifyFormContents()
-    {
-      var valid = true
-      var message = "Woops! You need to enter the following field(s):"
-      
-		if(this.preferredLanguage == "")  
-		{
-			message += " Preferred Language"
-			valid = false
-		}
 
-		if(this.householdFamilyName == "")  
-		{
-			if(!valid)
-			{
-				message +=","
-			}
-			message += " Last Name"
-			valid = false
-		}
-		
-		if(this.householdGivenName == "") 
-		{
-			if(!valid)
-			{
-				message +=","
-			}
-			message += " First Name"
-			valid = false
-		}
-		
-		if (this.householdDate == null) 
-		{
-			if(!valid)
-			{
-				message +=","
-			}
-			message += " Date of birth"
-			valid = false
-		}
-		
-		if(this.householdGender == "") 
-		{
-			if(!valid)
-			{
-				message +=","
-			}
-			message += " Gender Identity" 
-			valid = false
-		}
-
-		if(this.relationship == "") 
-		{
-			if(!valid)
-			{
-				message +=","
-			}
-			message += " Relationship" 
-			valid = false
-		}
-      
-		if (valid == false) 
-		{
-          alert(message)
-          return false
+      if (this.householdFamilyName == "") {
+        if (!valid) {
+          message += ",";
         }
-      
-        this.sendHouseholdPersonalInfoDataToReviewPage();
-        return true;
+        message += " Last Name";
+        valid = false;
+      }
+
+      if (this.householdGivenName == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " First Name";
+        valid = false;
+      }
+
+      if (this.householdDate == null) {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Date of birth";
+        valid = false;
+      }
+
+      if (this.householdGender == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Gender Identity";
+        valid = false;
+      }
+
+      if (this.relationship == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Relationship";
+        valid = false;
+      }
+
+      if (valid == false) {
+        alert(message);
+        return false;
+      }
+
+      this.sendHouseholdPersonalInfoDataToReviewPage();
+      return true;
     },
-	setHouseholdFamilyName(householdFamilyName)
-	{
-		this.householdFamilyName = householdFamilyName;
-	}
-},
+    setHouseholdFamilyName(householdFamilyName) {
+      this.householdFamilyName = householdFamilyName;
+    },
+  },
 };
 </script>

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
@@ -51,30 +51,29 @@
       <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-          ref="householdMenu"
-          v-model="householdMenu"
+          attach
           :close-on-content-click="false"
           transition="scale-transition"
           offset-y
           min-width="290px"
         >
-          <template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on }">
             <v-text-field
               v-model="householdDate"
               label="Date of Birth"
+              :rules="birthdateRules"
+              placeholder="YYYY-MM-DD"
+              v-mask="'####-##-##'"
               prepend-icon="mdi-calendar"
-              readonly
-              v-bind="attrs"
-              v-on="on"
+              @click:prepend="on.click"
             ></v-text-field>
           </template>
 
           <v-date-picker
-            ref="picker"
+            reactive
             v-model="householdDate"
-            min="1900-01-01"
+            :min="minDateStr"
             :max="maxDateStr"
-            @change="save"
           ></v-date-picker>
         </v-menu>
       </v-col>
@@ -189,19 +188,32 @@ export default {
       householdFamilyName: "",
       householdGivenName: "",
       householdSuffix: "",
-      householdBirthDate: "",
+      householdDate: "",
       householdGender: "",
       householdPatientPhoto: "",
       householdRaceSelections: "",
       householdEthnicitySelection: "",
       preferredLanguage: "",
       relationship: "",
+      minDateStr: "1900-01-01",
+      birthdateRules: [
+        (v) => !!v || "DOB is required",
+        (v) => v.length == 10 || "DOB must be in specified format",
+        (v) => this.validBirthdate(v) || "Invalid DOB",
+      ],
     };
   },
   props: {
     householdMemberNumber: Number,
   },
   methods: {
+    validBirthdate(birthdate) {
+      var minDate = Date.parse(this.minDateStr);
+      var maxDate = Date.parse(this.maxDateStr);
+      var date = Date.parse(birthdate);
+
+      return !Number.isNaN(date) && minDate <= date && date <= maxDate;
+    },
     sendHouseholdPersonalInfoDataToReviewPage() {
       const householdPersonalInfoPayload = {
         preferredLanguage: this.preferredLanguage,

--- a/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
@@ -1,135 +1,133 @@
 <template>
-	<v-container fluid>
+  <v-container fluid>
     <v-row align="center" justify="center">
-		<!-- Last name -->
-		<v-col class="d-flex" cols="5" sm="5">
-        <v-text-field 
-			label="Last Name" 
-			id="lastName" 
-			required
-			:rules="[v => !!v || 'Last name field is required']"
-			v-model="familyName"
-			prepend-icon="mdi-menu-right"
+      <!-- Last name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="Last Name"
+          id="lastName"
+          required
+          :rules="[(v) => !!v || 'Last name field is required']"
+          v-model="familyName"
+          prepend-icon="mdi-menu-right"
         ></v-text-field>
-		</v-col>
+      </v-col>
 
-		<!-- First name -->
-		<v-col class="d-flex" cols="5" sm="5">
-			<v-text-field 
-			label="First Name" 
-			id="firstName" 
-			required
-			:rules="[v => !!v || 'First name field is required']"
-			v-model="givenName">
-			</v-text-field>
-		</v-col>
+      <!-- First name -->
+      <v-col class="d-flex" cols="5" sm="5">
+        <v-text-field
+          label="First Name"
+          id="firstName"
+          required
+          :rules="[(v) => !!v || 'First name field is required']"
+          v-model="givenName"
+        >
+        </v-text-field>
+      </v-col>
 
-		<!-- Suffix -->
-		<v-col class="d-flex" cols="2" sm="2">
-			<v-text-field 
-			label="Suffix" 
-			id="suffix" 
-			v-model="suffix">
-			</v-text-field>
-		</v-col>
+      <!-- Suffix -->
+      <v-col class="d-flex" cols="2" sm="2">
+        <v-text-field label="Suffix" id="suffix" v-model="suffix">
+        </v-text-field>
+      </v-col>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-			ref="menu"
-			v-model="menu"
-				:close-on-content-click="false"
-				transition="scale-transition"
-				offset-y
+          ref="menu"
+          v-model="menu"
+          :close-on-content-click="false"
+          transition="scale-transition"
+          offset-y
           min-width="290px"
         >
-		<template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
-				v-model="date"
-				label="Date of Birth"
-				prepend-icon="mdi-calendar"
-				readonly
-				v-bind="attrs"
-				v-on="on"
+              v-model="date"
+              label="Date of Birth"
+              prepend-icon="mdi-calendar"
+              readonly
+              v-bind="attrs"
+              v-on="on"
             ></v-text-field>
-		</template>
+          </template>
 
-		<v-date-picker
+          <v-date-picker
             ref="picker"
             v-model="date"
             :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
             @change="save"
-		></v-date-picker>
+          ></v-date-picker>
         </v-menu>
-		</v-col>
+      </v-col>
 
-		<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Gender identity -->
         <v-select
-			:items="genderID"
-			label="Gender identity"
-			required
-			:rules="[v => !!v || 'Gender identity field is required']"
-			v-model="gender"
-			prepend-icon="mdi-menu-right"
-		></v-select>
-		</v-col>
+          :items="genderID"
+          label="Gender identity"
+          required
+          :rules="[(v) => !!v || 'Gender identity field is required']"
+          v-model="gender"
+          prepend-icon="mdi-menu-right"
+        ></v-select>
+      </v-col>
 
-		<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="left" justify="left">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Current Photo -->
         <v-file-input
-			:rules="rules"
-			accept="image/png, image/jpeg, image/bmp"
-			placeholder="Upload a recent photo"
-			v-model="patientPhoto"
-			label="Photo"
-			prepend-icon="mdi-camera"
+          :rules="rules"
+          accept="image/png, image/jpeg, image/bmp"
+          placeholder="Upload a recent photo"
+          v-model="patientPhoto"
+          label="Photo"
+          prepend-icon="mdi-camera"
         ></v-file-input>
-		</v-col>
+      </v-col>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Race -->
         <v-select
-			v-model="raceSelections"
-			:items="race"
-			label="Race (select all that apply)"
-			prepend-icon="mdi-menu-right"
-			multiple
+          v-model="raceSelections"
+          :items="race"
+          label="Race (select all that apply)"
+          prepend-icon="mdi-menu-right"
+          multiple
         ></v-select>
-		</v-col>
-		<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
 
     <v-row align="center" justify="center">
-		<v-col class="d-flex" cols="5" sm="5">
+      <v-col class="d-flex" cols="5" sm="5">
         <!-- Ethnicity -->
         <v-select
-			v-model="ethnicitySelection"
-			:items="ethnicity"
-			label="Ethnicity"
-			prepend-icon="mdi-menu-right"
+          v-model="ethnicitySelection"
+          :items="ethnicity"
+          label="Ethnicity"
+          prepend-icon="mdi-menu-right"
         ></v-select>
-		</v-col>
-		<v-spacer></v-spacer>
+      </v-col>
+      <v-spacer></v-spacer>
     </v-row>
-	</v-container>
+  </v-container>
 </template>
 
 <script>
-import EventBus from '../eventBus'
+import EventBus from "../eventBus";
 
 export default {
   data() {
@@ -148,20 +146,19 @@ export default {
         "Not Hispanic or Latino",
         "Unknown or prefer not to answer",
       ],
-      familyName: '',
-      givenName: '',
-      suffix: '',
-      birthDate: '',
-      gender: '',
-      patientPhoto: '',
-      raceSelections: '',
-			ethnicitySelection: '',
-			preferredLanguage: ''
+      familyName: "",
+      givenName: "",
+      suffix: "",
+      birthDate: "",
+      gender: "",
+      patientPhoto: "",
+      raceSelections: "",
+      ethnicitySelection: "",
+      preferredLanguage: "",
     };
   },
   methods: {
-    sendPersonalInfoDataToReviewPage()
-    {
+    sendPersonalInfoDataToReviewPage() {
       const personalInfoPayload = {
         familyName: this.familyName,
         givenName: this.givenName,
@@ -170,67 +167,58 @@ export default {
         gender: this.gender,
         patientPhoto: this.patientPhoto,
         raceSelections: this.raceSelections,
-				ethnicitySelection: this.ethnicitySelection,
-				preferredLanguage: this.preferredLanguage
-      }
-      EventBus.$emit('DATA_PERSONAL_INFO_PUBLISHED', personalInfoPayload)
+        ethnicitySelection: this.ethnicitySelection,
+        preferredLanguage: this.preferredLanguage,
+      };
+      EventBus.$emit("DATA_PERSONAL_INFO_PUBLISHED", personalInfoPayload);
     },
-    verifyFormContents()
-    {
-		//add logic to check form contents
-		var valid = true
-		var message = "Woops! You need to enter the following field(s):"
-		
-		if(this.familyName == "")  {
-			message += " Last Name"
-			valid = false
-		}
-		
-		if(this.givenName == "") 
-		{
-		if(!valid)
-				{
-				message +=","
-				}
-			message += " First Name"
-			valid = false
-		}
-		
-		
-		if (this.date == null) 
-		{
-		if(!valid)
-				{
-				message +=","
-				}
-			message += " Date of birth"
-			valid = false
-		}
-		
-		if(this.gender == "") 
-		{
-		if(!valid)
-				{
-				message +=","
-				}
-			message += " Gender Identity" 
-			valid = false
-		}
-		
-		if (valid == false) 
-		{
-				alert(message)
-				return false
-		}
-		
+    verifyFormContents() {
+      //add logic to check form contents
+      var valid = true;
+      var message = "Woops! You need to enter the following field(s):";
+
+      if (this.familyName == "") {
+        message += " Last Name";
+        valid = false;
+      }
+
+      if (this.givenName == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " First Name";
+        valid = false;
+      }
+
+      if (this.date == null) {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Date of birth";
+        valid = false;
+      }
+
+      if (this.gender == "") {
+        if (!valid) {
+          message += ",";
+        }
+        message += " Gender Identity";
+        valid = false;
+      }
+
+      if (valid == false) {
+        alert(message);
+        return false;
+      }
+
       this.sendPersonalInfoDataToReviewPage();
       return true;
-    }
-	},
-	mounted() {
-		EventBus.$on('DATA_LANGUAGE_INFO_PUBLISHED', (preferredLanguage) => {
-			this.preferredLanguage = preferredLanguage;
-		});
-	}
+    },
+  },
+  mounted() {
+    EventBus.$on("DATA_LANGUAGE_INFO_PUBLISHED", (preferredLanguage) => {
+      this.preferredLanguage = preferredLanguage;
+    });
+  },
 };
 </script>

--- a/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
@@ -57,8 +57,8 @@
           <v-date-picker
             ref="picker"
             v-model="date"
-            :max="new Date().toISOString().substr(0, 10)"
             min="1900-01-01"
+            :max="maxDateStr"
             @change="save"
           ></v-date-picker>
         </v-menu>
@@ -213,6 +213,18 @@ export default {
 
       this.sendPersonalInfoDataToReviewPage();
       return true;
+    },
+  },
+  computed: {
+    maxDateStr: function() {
+      let d = new Date();
+      let date = [
+        d.getFullYear(),
+        ("0" + (d.getMonth() + 1)).slice(-2),
+        ("0" + d.getDate()).slice(-2),
+      ].join("-");
+
+      return date;
     },
   },
   mounted() {

--- a/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
@@ -36,30 +36,29 @@
       <v-col class="d-flex" cols="5" sm="5">
         <!-- Date of Birth -->
         <v-menu
-          ref="menu"
-          v-model="menu"
+          attach
           :close-on-content-click="false"
           transition="scale-transition"
           offset-y
           min-width="290px"
         >
-          <template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on }">
             <v-text-field
               v-model="date"
               label="Date of Birth"
+              :rules="birthdateRules"
+              placeholder="YYYY-MM-DD"
+              v-mask="'####-##-##'"
               prepend-icon="mdi-calendar"
-              readonly
-              v-bind="attrs"
-              v-on="on"
+              @click:prepend="on.click"
             ></v-text-field>
           </template>
 
           <v-date-picker
-            ref="picker"
+            reactive
             v-model="date"
-            min="1900-01-01"
+            :min="minDateStr"
             :max="maxDateStr"
-            @change="save"
           ></v-date-picker>
         </v-menu>
       </v-col>
@@ -149,15 +148,28 @@ export default {
       familyName: "",
       givenName: "",
       suffix: "",
-      birthDate: "",
+      date: "",
       gender: "",
       patientPhoto: "",
       raceSelections: "",
       ethnicitySelection: "",
       preferredLanguage: "",
+      minDateStr: "1900-01-01",
+      birthdateRules: [
+        (v) => !!v || "DOB is required",
+        (v) => v.length == 10 || "DOB must be in specified format",
+        (v) => this.validBirthdate(v) || "Invalid DOB",
+      ],
     };
   },
   methods: {
+    validBirthdate(birthdate) {
+      var minDate = Date.parse(this.minDateStr);
+      var maxDate = Date.parse(this.maxDateStr);
+      var date = Date.parse(birthdate);
+
+      return !Number.isNaN(date) && minDate <= date && date <= maxDate;
+    },
     sendPersonalInfoDataToReviewPage() {
       const personalInfoPayload = {
         familyName: this.familyName,


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-389

## :newspaper: [Work Description]
- Prevent users from choosing a DOB in the future
- Add text input for DOB field

## :vertical_traffic_light: [Testing/QA Notes]
The max date for DOB is set by the current date time. However, there were issues because the date time used was in UTC timezone. Therefore, depending on the local timezone, the max date could be a day in advance. For example, EST is UTC -5 (EST is five hours behind UTC). At 7pm EST, it would be 12am UTC, the next date.

- To test the fix, open the date picker at a time when UTC date time is a day ahead local date time. Ensure the date picker does not allow dates in the future, relative to local region.
- The DOB should be able to be entered through the text field, and only valid dates are accepted.
- Verify the proper DOB information is displayed on the review page.
- This should work for SinglePersonalInfo, HouseholdPersonalInfo_1, and HouseholdPersonalInfo_n