### PR TITLE
Added Line Address 2

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -15,15 +15,24 @@
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
-					id = "addr"
 					required
 					:rules="[v => !!v || 'Address field is required']"
-					v-model="householdLineAddress"
+					v-model="householdLineAddress1"
 					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
-						<span class="red--text"><strong>* </strong></span>Home Address
+						<span class="red--text"><strong>* </strong></span>Address Line 1
 						</template>
+				</v-text-field>
+			</v-col>
+		</v-row>
+		<v-row>
+			<v-col cols="12" sm="12" md="12">
+				<v-text-field
+					v-model="householdLineAddress2"
+					v-show="homeAddressAvailable"
+					prepend-icon="mdi-menu-right"
+					label="Address Line 2">
 				</v-text-field>
 			</v-col>
 		</v-row>
@@ -118,7 +127,8 @@ import EventBus from '../eventBus'
 		'WA', 'WV', 'WI', 'WY',
 		],
 			country: ['USA'],
-			householdLineAddress: '',
+			householdLineAddress1: '',
+			householdLineAddress2: '',
 			householdCityAddress: '',
 			householdDistrictAddress: '',
 			householdStateAddress: '',
@@ -133,7 +143,8 @@ import EventBus from '../eventBus'
 		sendHouseholdHomeAddressInfoToReviewPage()
 		{
 			const householdHomeAddressPayload = {
-				householdLineAddress: this.householdLineAddress,
+				householdLineAddress1: this.householdLineAddress1,
+				householdLineAddress2: this.householdLineAddress2,
 				householdCityAddress: this.householdCityAddress,
 				householdDistrictAddress: this.householdDistrictAddress,
 				householdStateAddress: this.householdStateAddress,
@@ -150,7 +161,7 @@ import EventBus from '../eventBus'
 			
 		if(this.homeAddressAvailable)
 		{	
-			if(this.householdLineAddress == "") 
+			if(this.householdLineAddress1 == "") 
 			{
 				message += " Address"
 				valid = false
@@ -223,7 +234,8 @@ import EventBus from '../eventBus'
 	HomeAddressAvailable()
     {
 	this.homeAddressAvailable = true
-	this.householdLineAddress=""
+	this.householdLineAddress1=""
+	this.householdLineAddress2=""
 	this.householdCityAddress=""
 	this.householdStateAddress=""
 	this.householdDistrictAddress=""
@@ -232,7 +244,8 @@ import EventBus from '../eventBus'
     HomeAddressNotAvailable()
     {
 	this.homeAddressAvailable = false
-	this.householdLineAddress="Not Available"
+	this.householdLineAddress1="Not Available"
+	this.householdLineAddress2="Not Available"
 	this.householdCityAddress="Not Available"
 	this.householdStateAddress="Not Available"
 	this.householdDistrictAddress="Not Available"

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -208,9 +208,7 @@ export default {
       if (this.checkbox) {
         //all household members have the same last name
         EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", this.householdFamilyName);
-      } else {
-        EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", "");
-      }
+      } 
     },
     verifyFormContents() {
       //add logic to check form contents

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -4,15 +4,16 @@
 		</v-row>
 		<v-row>
 			<v-col cols="12" sm="6" md="3">
-				<div class="font-weight-medium primary--text">Household Home Address </div>
+				<div class="font-weight-medium primary--text">Household Address</div>
 			</v-col>
 		</v-row>
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-medium">Street Address:  <span class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress}}</span></div>
-				<div class="font-weight-medium">City, County, State, Country, Zip Code:  <span class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, 
-					{{dataHouseholdHomeAddress.householdDistrictAddress}}, {{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, {{dataHouseholdHomeAddress.householdPostalCode}}</span></div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}} {{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdDistrictAddress}}, 
+					{{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, 
+					{{dataHouseholdHomeAddress.householdPostalCode}}</div>
 			</v-col>
 		</v-row>
 

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -10,7 +10,10 @@
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}} {{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}}</div>
+				<template v-if="dataHouseholdHomeAddress.householdLineAddress2 != ''">
+					<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				</template>
 				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdDistrictAddress}}, 
 					{{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, 
 					{{dataHouseholdHomeAddress.householdPostalCode}}</div>

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -15,15 +15,24 @@
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
-					id = "addr"
 					required
 					:rules="[v => !!v || 'Address field is required']"
-					v-model="lineAddress"
+					v-model="lineAddress1"
 					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
-						<span class="red--text"><strong>* </strong></span>Home Address
+						<span class="red--text"><strong>* </strong></span>Address Line 1
 						</template>
+				</v-text-field>
+			</v-col>
+		</v-row>
+		<v-row>
+			<v-col cols="12" sm="12" md="12">
+				<v-text-field
+					v-model="lineAddress2"
+					v-show="homeAddressAvailable"
+					prepend-icon="mdi-menu-right"
+					label="Address Line 2">
 				</v-text-field>
 			</v-col>
 		</v-row>
@@ -125,7 +134,8 @@ import EventBus from '../eventBus'
 		'WA', 'WV', 'WI', 'WY',
 		],
 			country: ['USA'],
-			lineAddress: '',
+			lineAddress1: '',
+			lineAddress2: '',
 			cityAddress: '',
 			districtAddress: '',
 			stateAddress: '',
@@ -161,7 +171,8 @@ import EventBus from '../eventBus'
 		sendHomeAddressInfoToReviewPage()
 		{
 		const homeAddressPayload = {
-			lineAddress: this.lineAddress,
+			lineAddress1: this.lineAddress1,
+			lineAddress2: this.lineAddress2,
 			cityAddress: this.cityAddress,
 			districtAddress: this.districtAddress,
 			stateAddress: this.stateAddress,
@@ -178,7 +189,7 @@ import EventBus from '../eventBus'
 			
 		if(this.homeAddressAvailable)
 		{	
-			if(this.lineAddress == "") 
+			if(this.lineAddress1 == "") 
 			{
 				message += " Address"
 				valid = false
@@ -253,7 +264,8 @@ import EventBus from '../eventBus'
 	HomeAddressAvailable()
     {
 	this.homeAddressAvailable = true
-	this.lineAddress=""
+	this.lineAddress1=""
+	this.lineAddress2=""
 	this.cityAddress=""
 	this.stateAddress=""
 	this.districtAddress=""
@@ -262,7 +274,8 @@ import EventBus from '../eventBus'
     HomeAddressNotAvailable()
     {
 	this.homeAddressAvailable = false
-	this.lineAddress="Not Available"
+	this.lineAddress1="Not Available"
+	this.lineAddress2="Not Available"
 	this.cityAddress="Not Available"
 	this.stateAddress="Not Available"
 	this.districtAddress="Not Available"

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -34,7 +34,10 @@
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}} {{dataHomeAddress.lineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}}</div>
+				<template v-if="dataHomeAddress.lineAddress2 != ''">
+					<div class="font-weight-regular">{{dataHomeAddress.lineAddress2}}</div>
+				</template>
 				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
 					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
 			</v-col>

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -28,15 +28,15 @@
 		</v-row>
 		<v-row>
 			<v-col cols="12" sm="6" md="3">
-				<div class="font-weight-medium primary--text">Home Address </div>
+				<div class="font-weight-medium primary--text">Address</div>
 			</v-col>
 		</v-row>
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-medium">Street Address:  <span class="font-weight-regular">{{dataHomeAddress.lineAddress}}</span></div>
-				<div class="font-weight-medium">City, County, State, Country, Zip Code:  <span class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
-					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</span></div>
+				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}} {{dataHomeAddress.lineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
+					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
 			</v-col>
 		</v-row>
 


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-464

## :newspaper: [Work Description]
Changed "Home Address" (single field) into "Address Line 1" and "Address Line 2."  Updated SinglePatientHomeAddress, HouseholdHomeAddress, SinglePatientReviewSubmit, and HouseholdReviewSubmit accordingly.

## :vertical_traffic_light: [Testing/QA Notes]
- Build and load the application
Complete the following for the single AND household workflows:
- Enter a single-line home address
- Proceed to the "review and submit" page and verify that the address is represented correctly
- Go back and enter a 2-line address (e.g. specify "Apartment 2B" as address line 2)
- Proceed to the "review and submit" page and verify that the address is represented correctly; address line 1 should be on the first line, followed by address line 2
