### PR TITLE
[MVS-473] Need to implement zip code validation for Household home address page

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -83,7 +83,7 @@
 				<v-text-field
 					id = "zipcode"
 					required
-					:rules="[v => !!v || 'Zipcode field is required']"
+					:rules="postalCodeRules"
 					v-model="householdPostalCode"
 					v-show="homeAddressAvailable">
 						<template #label>
@@ -101,6 +101,13 @@ import EventBus from '../eventBus'
   export default {
 	data () {
 		return {
+			postalCodeRules: [
+        (v) => !!v || "Zip code is required",
+			(v) =>
+			/(^\d{5}$)|(^\d{5}-\d{4}$)/.test(v) ||
+			"Zip code must be in format of ##### or #####-####",
+		],
+		
 			state:[
 		'AL', 'AK', 'AS', 'AZ',
 		'AR', 'CA', 'CO', 'CT',

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -136,27 +136,6 @@ import EventBus from '../eventBus'
 		}				
 	},
 	
-	rules1: {
-        postalCode: [{
-			required: true,
-			message: 'Please enter Mobile Number',
-			trigger: 'blur'
-        }, {
-          min: 10,
-          max: 10,
-          message: 'Length must be 10',
-          trigger: 'blur'
-        }, {
-          pattern: /^\d*$/,
-          message: 'Must be all numbers',
-          trigger: 'blur'
-        }, {
-          pattern: /^[789]/,
-          message: 'Must start 7, 8 or 9',
-          trigger: 'blur'
-        }]
-      },
-	
 	methods: {
 		sendHomeAddressInfoToReviewPage()
 		{


### PR DESCRIPTION
…dress page

## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-473

## :newspaper: [Work Description]
Use the same zipcode validation method in the single patient home address page, in the household home address page.

## :vertical_traffic_light: [Testing/QA Notes]
- Run the patient registration app locally, make sure it compiles without any errors
- Go to the household home address page 
- Experiment with the zip code field and make sure it works properly (try inputting letters, more than 5 numbers, ...)
