### PR TITLE
[MVS-468] Update the readonly text fields of PatientInfoComponent.vue to also have the "outlined" attribute

### DIFF
--- a/PointOfDispensingApp/src/components/PatientInfoComponent.vue
+++ b/PointOfDispensingApp/src/components/PatientInfoComponent.vue
@@ -15,7 +15,7 @@
             <div class="font-weight-medium secondary--text">Patient ID</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined
               value="1234567890"
             ></v-text-field>
           </v-col>
@@ -25,7 +25,7 @@
             <div class="font-weight-medium secondary--text">Last Name</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="Smith"
             ></v-text-field>
           </v-col>
@@ -35,7 +35,7 @@
             <div class="font-weight-medium secondary--text">First Name</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="John"
             ></v-text-field>
           </v-col>
@@ -45,7 +45,7 @@
             <div class="font-weight-medium secondary--text">Date of Birth</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="01/01/1970"
             ></v-text-field>
           </v-col>
@@ -55,7 +55,7 @@
             <div class="font-weight-medium secondary--text">Gender</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="Male"
             ></v-text-field>
           </v-col>
@@ -65,7 +65,7 @@
             <div class="font-weight-medium secondary--text">Street Address</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="1234 Main Street"
             ></v-text-field>
           </v-col>
@@ -75,7 +75,7 @@
             <div class="font-weight-medium secondary--text">Preferred Language</div>
           </v-col>
           <v-col cols="4">
-            <v-text-field filled dense readonly
+            <v-text-field filled dense readonly outlined 
               value="English"
             ></v-text-field>
           </v-col>


### PR DESCRIPTION
… to also have the "outlined" attribute

## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-468

## :newspaper: [Work Description]
update the readonly text fields to have an outlined attribute in the Patient Info Component (patient ID, Last name, First name, DOB, Gender,...)

## :vertical_traffic_light: [Testing/QA Notes]
- Run the POD app locally, make sure it compiles without errors
- Go to Check In page 
- Make sure that the Patient Info text fields are outlined and read-only
