### PR TITLE
Mvs 469 implement logic in vaccination event page.vue to show/hide vaccination proceed component.vue or vaccination canceled component.vue

### DIFF
--- a/PointOfDispensingApp/config.js
+++ b/PointOfDispensingApp/config.js
@@ -1,5 +1,3 @@
-//file name is 'config.js'
-
 export default {
     vaccinationDecisionState:
     {

--- a/PointOfDispensingApp/config.js
+++ b/PointOfDispensingApp/config.js
@@ -1,0 +1,10 @@
+//file name is 'config.js'
+
+export default {
+    vaccinationDecisionState:
+    {
+        UNDETERMINED: 0,
+        VACCINATION_PROCEED_YES: 1,
+        VACCINATION_PROCEED_NO: 2   
+    }	
+}

--- a/PointOfDispensingApp/src/components/VaccinationEventPage.vue
+++ b/PointOfDispensingApp/src/components/VaccinationEventPage.vue
@@ -14,7 +14,7 @@
       <template v-if="wasDecisionMadeToProceed()">
       <VaccinationProceedComponent />
       </template>
-      <template v-if="wasDecisionMadeToCancel()">
+      <template v-else-if="wasDecisionMadeToCancel()">
       <VaccinationCanceledComponent />
       </template>
     </v-row>
@@ -34,14 +34,8 @@ import config from '../../config.js';
     {
       setVaccinationProceedDecision(decision)
       {
-        if(decision == true)
-        {
-          this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_YES
-        }
-        else
-        {
-          this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_NO
-        }
+        decision ? (this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_YES) :
+        (this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_NO);
       },
       wasDecisionMadeToProceed()
       {

--- a/PointOfDispensingApp/src/components/VaccinationEventPage.vue
+++ b/PointOfDispensingApp/src/components/VaccinationEventPage.vue
@@ -10,11 +10,11 @@
     </v-row>
     <v-row>
       <PatientInfoComponent />
-      <VaccinationScreeningComponent />
-      <template v-if="true">
+      <VaccinationScreeningComponent @VaccinationProceed_Yes="setVaccinationProceedDecision(true)" @VaccinationProceed_No="setVaccinationProceedDecision(false)"/>
+      <template v-if="wasDecisionMadeToProceed()">
       <VaccinationProceedComponent />
       </template>
-      <template v-if="false">
+      <template v-if="wasDecisionMadeToCancel()">
       <VaccinationCanceledComponent />
       </template>
     </v-row>
@@ -26,21 +26,42 @@ import PatientInfoComponent from './PatientInfoComponent';
 import VaccinationScreeningComponent from './VaccinationScreeningComponent';
 import VaccinationProceedComponent from './VaccinationProceedComponent';
 import VaccinationCanceledComponent from './VaccinationCanceledComponent';
+import config from '../../config.js';
 
   export default {
     name: 'VaccinationEventPage',
     methods: 
     {
+      setVaccinationProceedDecision(decision)
+      {
+        if(decision == true)
+        {
+          this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_YES
+        }
+        else
+        {
+          this.vaccinationProceedDecision = config.vaccinationDecisionState.VACCINATION_PROCEED_NO
+        }
+      },
+      wasDecisionMadeToProceed()
+      {
+        return (this.vaccinationProceedDecision == config.vaccinationDecisionState.VACCINATION_PROCEED_YES)
+      },
+      wasDecisionMadeToCancel()
+      {
+        return (this.vaccinationProceedDecision == config.vaccinationDecisionState.VACCINATION_PROCEED_NO)
+      }
     },
     components: 
     {
       PatientInfoComponent,
       VaccinationScreeningComponent,
       VaccinationProceedComponent,
-      VaccinationCanceledComponent
+      VaccinationCanceledComponent,
     },
     data () {
       return {
+        vaccinationProceedDecision: config.vaccinationDecisionState.UNDETERMINED
       }
     }
   }

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -109,21 +109,18 @@
           <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
+
           <v-row align="center" justify="center">
-            <v-col cols="2">
-                <v-radio
-                  v-model="vaccinationYes"
-                  label="Yes"
-                  value="Yes"
-                ></v-radio>
-            </v-col>
-            <v-col cols="2">   
-                <v-radio
-                  v-model="vaccinationNo"
-                  label="No"
-                  value="No"
-                ></v-radio>
-            </v-col>
+            <v-radio-group v-model="vaccinationProceed" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
           </v-row>
         </v-card>
       </v-col>
@@ -141,6 +138,10 @@
     name: 'VaccinationScreeningComponent',
     methods: 
     {
+      vaccinationSelected()
+      {
+        alert('selected')
+      }
     },
     components: 
     {

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -105,24 +105,23 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark height="50%" v-show="screeningComplete">
-          <v-card-title class="headline justify-center">
-              Proceed with vaccination?
-          </v-card-title>
-
-          <v-row align="center" justify="center">
-            <v-radio-group v-model="vaccinationProceed" row>
-                  <v-radio
-                    label="Yes"
-                    value="Yes"
-                  ></v-radio>
-                  <v-radio
-                    label="No"
-                    value="No"
-                  ></v-radio>
-              </v-radio-group>
-          </v-row>
-        </v-card>
+          <v-card class="mx-auto my-12" color="accent" dark height="50%" v-show="screeningComplete">
+            <v-card-title class="headline justify-center">
+                Proceed with vaccination?
+            </v-card-title>
+            <v-row align="center" justify="center">
+              <v-radio-group v-model="vaccinationProceed" row>
+                    <v-radio
+                      label="Yes"
+                      value="Yes"
+                    ></v-radio>
+                    <v-radio
+                      label="No"
+                      value="No"
+                    ></v-radio>
+                </v-radio-group>
+            </v-row>
+          </v-card>
       </v-col>
     </v-row>
     <v-row>

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -159,7 +159,7 @@
        {
          this.$emit('VaccinationProceed_Yes')
        }
-       else if(this.vaccinationProceed == "No")
+       else
        {
          this.$emit('VaccinationProceed_No')
        }

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -110,7 +110,7 @@
                 Proceed with vaccination?
             </v-card-title>
             <v-row align="center" justify="center">
-              <v-radio-group v-model="vaccinationProceed" row>
+              <v-radio-group v-model="vaccinationProceed" row @change="vaccinationProceedDecision()">
                     <v-radio
                       label="Yes"
                       value="Yes"
@@ -152,6 +152,17 @@
      isScreeningChecklistComplete()
      {
        return (this.patientInfoComfirmed && this.consentFormSigned && this.screeningCompleted && this.factSheetProvided); 
+     },
+     vaccinationProceedDecision()
+     {
+       if(this.vaccinationProceed == "Yes")
+       {
+         this.$emit('VaccinationProceed_Yes')
+       }
+       else if(this.vaccinationProceed == "No")
+       {
+         this.$emit('VaccinationProceed_No')
+       }
      }
     },
     components: 

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -14,7 +14,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="patientInfoComfirmed" row>
+              <v-radio-group v-model="patientInfoComfirmed" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -39,7 +39,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="consentFormSigned" row>
+              <v-radio-group v-model="consentFormSigned" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -64,7 +64,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="screeningCompleted" row>
+              <v-radio-group v-model="screeningCompleted" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -89,7 +89,7 @@
           </v-col>
           <v-col cols="6">
             <v-row no-gutters>
-              <v-radio-group v-model="factSheetProvided" row>
+              <v-radio-group v-model="factSheetProvided" row @change="screeningChecklistUpdate()">
                   <v-radio
                     label="Yes"
                     value="Yes"
@@ -105,7 +105,7 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark height="50%" v-show="true">
+        <v-card color="accent" dark height="50%" v-show="screeningComplete">
           <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
@@ -134,20 +134,33 @@
 </template>
 
 <script>
+
   export default {
     name: 'VaccinationScreeningComponent',
     methods: 
     {
-      vaccinationSelected()
-      {
-        alert('selected')
-      }
+     screeningChecklistUpdate()
+     {
+       if(this.isScreeningChecklistComplete())
+       {
+         this.screeningComplete = true
+       }
+       else
+       {
+         this.screeningComplete = false
+       }
+     },
+     isScreeningChecklistComplete()
+     {
+       return (this.patientInfoComfirmed && this.consentFormSigned && this.screeningCompleted && this.factSheetProvided); 
+     }
     },
     components: 
     {
     },
     data () {
       return {
+        screeningComplete: false
       }
     }
   }

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-container>
-    <v-row>
+  <v-container fill-height fluid>
+    <v-row no-gutters>
       <v-col cols="6">
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Patient info confirmed? </div>
@@ -13,7 +13,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="patientInfoComfirmed" row>
                   <v-radio
                     label="Yes"
@@ -27,9 +27,9 @@
             </v-row>
           </v-col>
         </v-row> 
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Consent form signed?</div>
@@ -38,7 +38,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="consentFormSigned" row>
                   <v-radio
                     label="Yes"
@@ -52,9 +52,9 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>Proper screening completed?</div>
@@ -63,7 +63,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="screeningCompleted" row>
                   <v-radio
                     label="Yes"
@@ -77,9 +77,9 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row no-gutters>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group>
                 <template v-slot:label>
                   <div>VIS fact sheet provided?</div>
@@ -88,7 +88,7 @@
             </v-row>
           </v-col>
           <v-col cols="6">
-            <v-row>
+            <v-row no-gutters>
               <v-radio-group v-model="factSheetProvided" row>
                   <v-radio
                     label="Yes"
@@ -105,22 +105,24 @@
       </v-col>
                 
       <v-col cols="6">
-        <v-card color="accent" dark>
-          <v-card-title style="center" class="headline">
+        <v-card color="accent" dark height="50%" v-show="true">
+          <v-card-title class="headline justify-center">
               Proceed with vaccination?
           </v-card-title>
           <v-row align="center" justify="center">
-            <v-col cols="12">
-              <v-radio-group v-model="row" row>
+            <v-col cols="2">
                 <v-radio
+                  v-model="vaccinationYes"
                   label="Yes"
                   value="Yes"
                 ></v-radio>
+            </v-col>
+            <v-col cols="2">   
                 <v-radio
+                  v-model="vaccinationNo"
                   label="No"
                   value="No"
                 ></v-radio>
-              </v-radio-group>
             </v-col>
           </v-row>
         </v-card>

--- a/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationScreeningComponent.vue
@@ -3,66 +3,107 @@
     <v-row>
       <v-col cols="6">
         <v-row>
-          <v-radio-group v-model="patientInfoComfirmed" row>
-            <template v-slot:label>
-              <div>Patient info confirmed? </div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Patient info confirmed? </div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="patientInfoComfirmed" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+        </v-row> 
+        <v-row>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Consent form signed?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="consentFormSigned" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
         <v-row>
-          <v-radio-group v-model="consentFormSigned" row>
-            <template v-slot:label>
-              <div>Consent form signed?<v-spacer></v-spacer></div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>Proper screening completed?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="screeningCompleted" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
         <v-row>
-          <v-radio-group v-model="screeningCompleted" row>
-            <template v-slot:label>
-              <div>Proper screening completed?</div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
-        </v-row>
-        <v-row>
-          <v-radio-group v-model="factSheetProvided" row>
-            <template v-slot:label>
-              <div>VIS fact sheet provided?</div>
-            </template>
-            <v-radio
-              label="Yes"
-              value="Yes"
-            ></v-radio>
-            <v-radio
-              label="No"
-              value="No"
-            ></v-radio>
-          </v-radio-group>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group>
+                <template v-slot:label>
+                  <div>VIS fact sheet provided?</div>
+                </template>
+              </v-radio-group>
+            </v-row>
+          </v-col>
+          <v-col cols="6">
+            <v-row>
+              <v-radio-group v-model="factSheetProvided" row>
+                  <v-radio
+                    label="Yes"
+                    value="Yes"
+                  ></v-radio>
+                  <v-radio
+                    label="No"
+                    value="No"
+                  ></v-radio>
+              </v-radio-group>
+            </v-row>
+          </v-col>
         </v-row>
       </v-col>
+                
       <v-col cols="6">
         <v-card color="accent" dark>
           <v-card-title style="center" class="headline">


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-469

## :newspaper: [Work Description]
NOTE:  This branch is based on MVS-423
Implemented changes to make the "Proceed with vaccination?" response determine whether the VaccinationProceedComponent.vue or the VaccinationCanceledComponent.vue is displayed.  Until that "Proceed with vaccination?" question is answered, neither VaccinationProceedComponent.vue nor the VaccinationCanceledComponent.vue are displayed.

## :vertical_traffic_light: [Testing/QA Notes]
- Build and load the application
- Go to the Vaccination Event page
- Verify that there is nothing displayed below the vaccination screening questions
- Complete the 4 screening questions along the left side
- The "Proceed with vaccination?" question will be displayed once the 4 screening questions are answered
- Select "yes" - verify that the VaccinationProceedComponent.vue is displayed (which is used to document vaccine info)
- Select "no" - verify that the VaccinationCanceledComponent.vue is displayed (which is used to document why vaccine will not be administered)
