### PR TITLE
MVS-466 add patient address type as a field for patient registration

### DIFF
--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -48,7 +48,7 @@
 								<!-- Single Patient: Home Address -->
 								<v-stepper-content step="2">
 									<v-toolbar flat >
-										<v-toolbar-title>Enter your home address</v-toolbar-title>
+										<v-toolbar-title>Enter your address</v-toolbar-title>
 									</v-toolbar>
 									<v-card flat><SinglePatientHomeAddress ref="singlepatienthomeaddress"/></v-card>				
 								</v-stepper-content>

--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -15,15 +15,24 @@
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
-					id = "addr"
 					required
 					:rules="[v => !!v || 'Address field is required']"
-					v-model="householdLineAddress"
+					v-model="householdLineAddress1"
 					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
-						<span class="red--text"><strong>* </strong></span>Home Address
+						<span class="red--text"><strong>* </strong></span>Address Line 1
 						</template>
+				</v-text-field>
+			</v-col>
+		</v-row>
+		<v-row>
+			<v-col cols="12" sm="12" md="12">
+				<v-text-field
+					v-model="householdLineAddress2"
+					v-show="homeAddressAvailable"
+					prepend-icon="mdi-menu-right"
+					label="Address Line 2">
 				</v-text-field>
 			</v-col>
 		</v-row>
@@ -118,7 +127,8 @@ import EventBus from '../eventBus'
 		'WA', 'WV', 'WI', 'WY',
 		],
 			country: ['USA'],
-			householdLineAddress: '',
+			householdLineAddress1: '',
+			householdLineAddress2: '',
 			householdCityAddress: '',
 			householdDistrictAddress: '',
 			householdStateAddress: '',
@@ -133,7 +143,8 @@ import EventBus from '../eventBus'
 		sendHouseholdHomeAddressInfoToReviewPage()
 		{
 			const householdHomeAddressPayload = {
-				householdLineAddress: this.householdLineAddress,
+				householdLineAddress1: this.householdLineAddress1,
+				householdLineAddress2: this.householdLineAddress2,
 				householdCityAddress: this.householdCityAddress,
 				householdDistrictAddress: this.householdDistrictAddress,
 				householdStateAddress: this.householdStateAddress,
@@ -150,7 +161,7 @@ import EventBus from '../eventBus'
 			
 		if(this.homeAddressAvailable)
 		{	
-			if(this.householdLineAddress == "") 
+			if(this.householdLineAddress1 == "") 
 			{
 				message += " Address"
 				valid = false
@@ -223,7 +234,8 @@ import EventBus from '../eventBus'
 	HomeAddressAvailable()
     {
 	this.homeAddressAvailable = true
-	this.householdLineAddress=""
+	this.householdLineAddress1=""
+	this.householdLineAddress2=""
 	this.householdCityAddress=""
 	this.householdStateAddress=""
 	this.householdDistrictAddress=""
@@ -232,7 +244,8 @@ import EventBus from '../eventBus'
     HomeAddressNotAvailable()
     {
 	this.homeAddressAvailable = false
-	this.householdLineAddress="Not Available"
+	this.householdLineAddress1="Not Available"
+	this.householdLineAddress2="Not Available"
 	this.householdCityAddress="Not Available"
 	this.householdStateAddress="Not Available"
 	this.householdDistrictAddress="Not Available"

--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -37,7 +37,7 @@
 			</v-col>
 		</v-row>
 		<v-row>
-			<v-col cols="6" sm="4" md="3">
+			<v-col cols="5" sm="5" md="5">
 				<v-text-field
 					id = "city"
 					required
@@ -50,7 +50,7 @@
 						</template>
 				</v-text-field>
 			</v-col>
-			<v-col class="d-flex" cols="1" sm="1" md="1">
+			<v-col class="d-flex" cols="2" sm="2" md="2">
 				<v-select
 				id = "state"
 					required
@@ -63,19 +63,7 @@
 						</template>
 				</v-select>
 			</v-col>
-			<v-col class="d-flex" cols="3" sm="3">
-				<v-text-field
-				id = "county"
-					required
-					:rules="[v => !!v || 'County field is required']"
-					v-model="householdDistrictAddress"
-					v-show="homeAddressAvailable">
-						<template #label>
-						<span class="red--text"><strong>* </strong></span>County
-						</template>
-				</v-text-field>
-			</v-col>
-			<v-col class="d-flex" cols="2" sm="2">
+			<v-col class="d-flex" cols="2" sm="2" md="2">
 				<v-select
 				id = "country"
 					required
@@ -130,7 +118,6 @@ import EventBus from '../eventBus'
 			householdLineAddress1: '',
 			householdLineAddress2: '',
 			householdCityAddress: '',
-			householdDistrictAddress: '',
 			householdStateAddress: '',
 			householdCountryAddress: 'USA',
 			householdPostalCode: '',
@@ -146,7 +133,6 @@ import EventBus from '../eventBus'
 				householdLineAddress1: this.householdLineAddress1,
 				householdLineAddress2: this.householdLineAddress2,
 				householdCityAddress: this.householdCityAddress,
-				householdDistrictAddress: this.householdDistrictAddress,
 				householdStateAddress: this.householdStateAddress,
 				householdCountryAddress: this.householdCountryAddress,
 				householdPostalCode: this.householdPostalCode
@@ -190,17 +176,6 @@ import EventBus from '../eventBus'
 			}
 				
 			
-			if(this.householdDistrictAddress == "") 
-			{
-			if(!valid)
-				{
-				message +=","
-				}
-				message += " County"
-				valid = false
-			}
-				
-			
 			if(this.householdCountryAddress == "") 
 			{
 			if(!valid)
@@ -238,7 +213,6 @@ import EventBus from '../eventBus'
 	this.householdLineAddress2=""
 	this.householdCityAddress=""
 	this.householdStateAddress=""
-	this.householdDistrictAddress=""
 	this.householdPostalCode=""
     },
     HomeAddressNotAvailable()
@@ -248,7 +222,6 @@ import EventBus from '../eventBus'
 	this.householdLineAddress2="Not Available"
 	this.householdCityAddress="Not Available"
 	this.householdStateAddress="Not Available"
-	this.householdDistrictAddress="Not Available"
 	this.householdPostalCode="Not Available"
     },
 	},

--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -1,41 +1,42 @@
 <template>
 	<v-container fluid>
 	<v-row>
-     <v-radio-group
-        required
-        :rules="[v => !!v || 'This field is required']"
-        v-model="homeAddressAvailableRadioButtons"
-      >
-        <v-col align="right" cols="12">
-          <v-radio label="I have a home address" value="yes" @change="HomeAddressAvailable()"></v-radio>
-          <v-radio label="I do not have a home address" value="no" @change="HomeAddressNotAvailable()"></v-radio>
-        </v-col>
-      </v-radio-group>
-    </v-row>
-		<v-row>
-			<v-col cols="12" sm="12" md="12">
-				<v-text-field
-					required
-					:rules="[v => !!v || 'Address field is required']"
-					v-model="householdLineAddress1"
-					v-show="homeAddressAvailable"
-					prepend-icon="mdi-menu-right">
-						<template #label>
-						<span class="red--text"><strong>* </strong></span>Address Line 1
-						</template>
-				</v-text-field>
-			</v-col>
-		</v-row>
-		<v-row>
-			<v-col cols="12" sm="12" md="12">
-				<v-text-field
-					v-model="householdLineAddress2"
-					v-show="homeAddressAvailable"
-					prepend-icon="mdi-menu-right"
-					label="Address Line 2">
-				</v-text-field>
-			</v-col>
-		</v-row>
+		<v-col cols="5" sm="5" md="5">
+			<v-select
+				required
+				:rules="[v => !!v || 'Address Type is required']"
+				v-model="addressType"
+				:items="addressTypeOptions"
+				prepend-icon="mdi-menu-right"
+			>
+				<template #label>
+					<span class="red--text"><strong>* </strong></span>Address Type
+				</template>
+			</v-select>
+		</v-col>
+	</v-row>
+	<v-row>
+		<v-col cols="12" sm="12" md="12">
+			<v-text-field
+				required
+				:rules="[v => !!v || 'Address field is required']"
+				v-model="householdLineAddress1"
+				prepend-icon="mdi-menu-right">
+					<template #label>
+					<span class="red--text"><strong>* </strong></span>Address Line 1
+					</template>
+			</v-text-field>
+		</v-col>
+	</v-row>
+	<v-row>
+		<v-col cols="12" sm="12" md="12">
+			<v-text-field
+				v-model="householdLineAddress2"
+				prepend-icon="mdi-menu-right"
+				label="Address Line 2">
+			</v-text-field>
+		</v-col>
+	</v-row>
 		<v-row>
 			<v-col cols="5" sm="5" md="5">
 				<v-text-field
@@ -43,7 +44,6 @@
 					required
 					:rules="[v => !!v || 'City field is required']"
 					v-model="householdCityAddress"
-					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>City
@@ -56,8 +56,7 @@
 					required
 					:rules="[v => !!v || 'State field is required']"
 					v-model="householdStateAddress"
-					v-show="homeAddressAvailable"
-                    :items="state">
+					:items="state">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>State
 						</template>
@@ -69,8 +68,7 @@
 					required
 					:rules="[v => !!v || 'Country field is required']"
 					v-model="householdCountryAddress"
-					v-show="homeAddressAvailable"
-                    :items="country">
+					:items="country">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>Country
 						</template>
@@ -81,8 +79,7 @@
 					id = "zipcode"
 					required
 					:rules="[v => !!v || 'Zipcode field is required']"
-					v-model="householdPostalCode"
-					v-show="homeAddressAvailable">
+					v-model="householdPostalCode">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>Zipcode
 						</template>
@@ -114,15 +111,15 @@ import EventBus from '../eventBus'
 		'TX', 'UT', 'VT', 'VI', 'VA',
 		'WA', 'WV', 'WI', 'WY',
 		],
+			addressTypeOptions: ["Home", "Business", "Temporary"],
 			country: ['USA'],
+			addressType: '',
 			householdLineAddress1: '',
 			householdLineAddress2: '',
 			householdCityAddress: '',
 			householdStateAddress: '',
 			householdCountryAddress: 'USA',
 			householdPostalCode: '',
-			homeAddressAvailable: true,
-			homeAddressAvailableRadioButtons: 'yes'
 		}
 		
 	},
@@ -130,6 +127,7 @@ import EventBus from '../eventBus'
 		sendHouseholdHomeAddressInfoToReviewPage()
 		{
 			const householdHomeAddressPayload = {
+				addressType: this.addressType,
 				householdLineAddress1: this.householdLineAddress1,
 				householdLineAddress2: this.householdLineAddress2,
 				householdCityAddress: this.householdCityAddress,
@@ -144,15 +142,21 @@ import EventBus from '../eventBus'
 			//add logic to check form contents
 			var valid = true
 			var message = "Woops! You need to enter the following field(s):"
-			
-		if(this.homeAddressAvailable)
-		{	
+
+			if(this.addressType == "") 
+			{
+				message += " Address Type"
+				valid = false
+			}	
+		
 			if(this.householdLineAddress1 == "") 
 			{
+				if(!valid){
+					message +=","
+				}
 				message += " Address"
 				valid = false
 			}
-			
 			
 			if(this.householdCityAddress == "") 
 			{
@@ -196,7 +200,7 @@ import EventBus from '../eventBus'
 				message += " Zipcode"
 				valid = false
 			}
-		}
+
 			if (valid == false) 
 			{
 				alert(message)
@@ -206,24 +210,6 @@ import EventBus from '../eventBus'
 			this.sendHouseholdHomeAddressInfoToReviewPage();
 			return true;
 		},
-	HomeAddressAvailable()
-    {
-	this.homeAddressAvailable = true
-	this.householdLineAddress1=""
-	this.householdLineAddress2=""
-	this.householdCityAddress=""
-	this.householdStateAddress=""
-	this.householdPostalCode=""
-    },
-    HomeAddressNotAvailable()
-    {
-	this.homeAddressAvailable = false
-	this.householdLineAddress1="Not Available"
-	this.householdLineAddress2="Not Available"
-	this.householdCityAddress="Not Available"
-	this.householdStateAddress="Not Available"
-	this.householdPostalCode="Not Available"
-    },
 	},
   }
 </script>

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -208,9 +208,7 @@ export default {
       if (this.checkbox) {
         //all household members have the same last name
         EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", this.householdFamilyName);
-      } else {
-        EventBus.$emit("DATA_HOUSEHOLD_FAMILY_NAME", "");
-      }
+      } 
     },
     verifyFormContents() {
       //add logic to check form contents

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -4,15 +4,16 @@
 		</v-row>
 		<v-row>
 			<v-col cols="12" sm="6" md="3">
-				<div class="font-weight-medium primary--text">Household Home Address </div>
+				<div class="font-weight-medium primary--text">Household Address</div>
 			</v-col>
 		</v-row>
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-medium">Street Address:  <span class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress}}</span></div>
-				<div class="font-weight-medium">City, County, State, Country, Zip Code:  <span class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, 
-					{{dataHouseholdHomeAddress.householdDistrictAddress}}, {{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, {{dataHouseholdHomeAddress.householdPostalCode}}</span></div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}} {{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdDistrictAddress}}, 
+					{{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, 
+					{{dataHouseholdHomeAddress.householdPostalCode}}</div>
 			</v-col>
 		</v-row>
 

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -10,6 +10,7 @@
 
 		<v-row>	
 			<v-col cols="12">
+				<div class="font-weight-medium">Address Type:  <span class="font-weight-regular">{{dataHouseholdHomeAddress.addressType}}</span></div>
 				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}}</div>
 				<template v-if="dataHouseholdHomeAddress.householdLineAddress2 != ''">
 					<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress2}}</div>

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -14,9 +14,8 @@
 				<template v-if="dataHouseholdHomeAddress.householdLineAddress2 != ''">
 					<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress2}}</div>
 				</template>
-				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdDistrictAddress}}, 
-					{{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, 
-					{{dataHouseholdHomeAddress.householdPostalCode}}</div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdStateAddress}}, 
+					{{dataHouseholdHomeAddress.householdCountryAddress}}, {{dataHouseholdHomeAddress.householdPostalCode}}</div>
 			</v-col>
 		</v-row>
 

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -10,7 +10,10 @@
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}} {{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress1}}</div>
+				<template v-if="dataHouseholdHomeAddress.householdLineAddress2 != ''">
+					<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdLineAddress2}}</div>
+				</template>
 				<div class="font-weight-regular">{{dataHouseholdHomeAddress.householdCityAddress}}, {{dataHouseholdHomeAddress.householdDistrictAddress}}, 
 					{{dataHouseholdHomeAddress.householdStateAddress}}, {{dataHouseholdHomeAddress.householdCountryAddress}}, 
 					{{dataHouseholdHomeAddress.householdPostalCode}}</div>

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -1,16 +1,19 @@
 <template>
 	<v-container fluid>
 	<v-row>
-     <v-radio-group
-        required
-        :rules="[v => !!v || 'This field is required']"
-        v-model="homeAddressAvailableRadioButtons"
-      >
-        <v-col align="right" cols="12">
-          <v-radio label="I have a home address" value="yes" @change="HomeAddressAvailable()"></v-radio>
-          <v-radio label="I do not have a home address" value="no" @change="HomeAddressNotAvailable()"></v-radio>
-        </v-col>
-      </v-radio-group>
+		<v-col cols="5" sm="5" md="5">
+			<v-select
+				required
+				:rules="[v => !!v || 'Address Type is required']"
+				v-model="addressType"
+				:items="addressTypeOptions"
+				prepend-icon="mdi-menu-right"
+			>
+				<template #label>
+					<span class="red--text"><strong>* </strong></span>Address Type
+				</template>
+			</v-select>
+		</v-col>
     </v-row>
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
@@ -18,7 +21,6 @@
 					required
 					:rules="[v => !!v || 'Address field is required']"
 					v-model="lineAddress1"
-					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>Address Line 1
@@ -30,7 +32,6 @@
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
 					v-model="lineAddress2"
-					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right"
 					label="Address Line 2">
 				</v-text-field>
@@ -43,7 +44,6 @@
 					required
 					:rules="[v => !!v || 'City field is required']"
 					v-model="cityAddress"
-					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>City
@@ -56,8 +56,7 @@
 					required
 					:rules="[v => !!v || 'State field is required']"
 					v-model="stateAddress"
-					v-show="homeAddressAvailable"
-                    :items="state">
+					:items="state">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>State
 						</template>
@@ -69,8 +68,7 @@
 					required
 					:rules="[v => !!v || 'Country field is required']"
 					v-model="countryAddress"
-					v-show="homeAddressAvailable"
-                    :items="country">
+					:items="country">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>Country
 						</template>
@@ -81,8 +79,7 @@
 					id = "zipcode"
 					required
 					:rules="postalCodeRules"
-					v-model="postalCode"
-					v-show="homeAddressAvailable">
+					v-model="postalCode">
 						<template #label>
 						<span class="red--text"><strong>* </strong></span>Zipcode
 						</template>
@@ -121,43 +118,23 @@ import EventBus from '../eventBus'
 		'TX', 'UT', 'VT', 'VI', 'VA',
 		'WA', 'WV', 'WI', 'WY',
 		],
+			addressTypeOptions: ["Home", "Business", "Temporary"],
 			country: ['USA'],
+			addressType: '',
 			lineAddress1: '',
 			lineAddress2: '',
 			cityAddress: '',
 			stateAddress: '',
 			countryAddress: 'USA',
 			postalCode: '',
-			homeAddressAvailable: true,
-			homeAddressAvailableRadioButtons: 'yes'
 		}				
 	},
-	
-	rules1: {
-        postalCode: [{
-			required: true,
-			message: 'Please enter Mobile Number',
-			trigger: 'blur'
-        }, {
-          min: 10,
-          max: 10,
-          message: 'Length must be 10',
-          trigger: 'blur'
-        }, {
-          pattern: /^\d*$/,
-          message: 'Must be all numbers',
-          trigger: 'blur'
-        }, {
-          pattern: /^[789]/,
-          message: 'Must start 7, 8 or 9',
-          trigger: 'blur'
-        }]
-      },
 	
 	methods: {
 		sendHomeAddressInfoToReviewPage()
 		{
 		const homeAddressPayload = {
+			addressType: this.addressType,
 			lineAddress1: this.lineAddress1,
 			lineAddress2: this.lineAddress2,
 			cityAddress: this.cityAddress,
@@ -173,87 +150,74 @@ import EventBus from '../eventBus'
 			var valid = true
 			var message = "Woops! You need to enter the following field(s):"
 			
-		if(this.homeAddressAvailable)
-		{	
-			if(this.lineAddress1 == "") 
-			{
-				message += " Address"
-				valid = false
+		if(this.addressType == "") 
+		{
+			message += " Address Type"
+			valid = false
+		}
+		
+		if(this.lineAddress1 == "") 
+		{
+			if(!valid) {
+				message +=","
 			}
+			message += " Address"
+			valid = false
+		}
 			
 			
-			if(this.cityAddress == "") 
-			{
+		if(this.cityAddress == "") 
+		{
 			if(!valid)
 				{
 				message +=","
 				}
 				message += " City"
 				valid = false
-			}
+		}
 				
 			
-			if(this.stateAddress == "") 
-			{
+		if(this.stateAddress == "") 
+		{
 			if(!valid)
 				{
 				message +=","
 				}
 				message += " State"
 				valid = false
-			}
+		}
 				
 			
-			if(this.countryAddress == "") 
-			{
+		if(this.countryAddress == "") 
+		{
 			if(!valid)
 				{
 				message +=","
 				}
 				message += " Country"
 				valid = false
-			}
+		}
 				
 			
-			if(this.postalCode == "") 
-			{
+		if(this.postalCode == "") 
+		{
 			if(!valid)
 				{
 				message +=","
 				}
 				message += " Zipcode"
 				valid = false
-			}
-			
 		}
 
-			if (valid == false) 
-			{
-				alert(message)
-				return false
-			}
-			
-			this.sendHomeAddressInfoToReviewPage();
-			return true;
-		},
-	HomeAddressAvailable()
-    {
-	this.homeAddressAvailable = true
-	this.lineAddress1=""
-	this.lineAddress2=""
-	this.cityAddress=""
-	this.stateAddress=""
-	this.postalCode=""
-    },
-    HomeAddressNotAvailable()
-    {
-	this.homeAddressAvailable = false
-	this.lineAddress1="Not Available"
-	this.lineAddress2="Not Available"
-	this.cityAddress="Not Available"
-	this.stateAddress="Not Available"
-	this.postalCode="Not Available"
-    },
+		if (valid == false) 
+		{
+			alert(message)
+			return false
+		}
+		
+		this.sendHomeAddressInfoToReviewPage();
+		return true;
 	},
+	}
 }
 </script>

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -37,7 +37,7 @@
 			</v-col>
 		</v-row>
 		<v-row>
-			<v-col cols="6" sm="4" md="3">
+			<v-col cols="5" sm="5" md="5">
 				<v-text-field
 					id = "city"
 					required
@@ -50,7 +50,7 @@
 						</template>
 				</v-text-field>
 			</v-col>
-				<v-col class="d-flex" cols="1" sm="1" md="1">
+				<v-col class="d-flex" cols="2" sm="2" md="2">
 				<v-select
 				id = "state"
 					required
@@ -63,19 +63,7 @@
 						</template>
 				</v-select>
 			</v-col>
-			<v-col class="d-flex" cols="3" sm="3">
-				<v-text-field
-				id = "county"
-					required
-					:rules="[v => !!v || 'County field is required']"
-					v-model="districtAddress"
-					v-show="homeAddressAvailable">
-						<template #label>
-						<span class="red--text"><strong>* </strong></span>County
-						</template>
-				</v-text-field>
-			</v-col>
-			<v-col class="d-flex" cols="2" sm="2">
+			<v-col class="d-flex" cols="2" sm="2" md="2">
 				<v-select
 				id = "country"
 					required
@@ -137,7 +125,6 @@ import EventBus from '../eventBus'
 			lineAddress1: '',
 			lineAddress2: '',
 			cityAddress: '',
-			districtAddress: '',
 			stateAddress: '',
 			countryAddress: 'USA',
 			postalCode: '',
@@ -174,7 +161,6 @@ import EventBus from '../eventBus'
 			lineAddress1: this.lineAddress1,
 			lineAddress2: this.lineAddress2,
 			cityAddress: this.cityAddress,
-			districtAddress: this.districtAddress,
 			stateAddress: this.stateAddress,
 			countryAddress: this.countryAddress,
 			postalCode: this.postalCode
@@ -218,17 +204,6 @@ import EventBus from '../eventBus'
 			}
 				
 			
-			if(this.districtAddress == "") 
-			{
-			if(!valid)
-				{
-				message +=","
-				}
-				message += " County"
-				valid = false
-			}
-				
-			
 			if(this.countryAddress == "") 
 			{
 			if(!valid)
@@ -268,7 +243,6 @@ import EventBus from '../eventBus'
 	this.lineAddress2=""
 	this.cityAddress=""
 	this.stateAddress=""
-	this.districtAddress=""
 	this.postalCode=""
     },
     HomeAddressNotAvailable()
@@ -278,7 +252,6 @@ import EventBus from '../eventBus'
 	this.lineAddress2="Not Available"
 	this.cityAddress="Not Available"
 	this.stateAddress="Not Available"
-	this.districtAddress="Not Available"
 	this.postalCode="Not Available"
     },
 	},

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -15,15 +15,24 @@
 		<v-row>
 			<v-col cols="12" sm="12" md="12">
 				<v-text-field
-					id = "addr"
 					required
 					:rules="[v => !!v || 'Address field is required']"
-					v-model="lineAddress"
+					v-model="lineAddress1"
 					v-show="homeAddressAvailable"
 					prepend-icon="mdi-menu-right">
 						<template #label>
-						<span class="red--text"><strong>* </strong></span>Home Address
+						<span class="red--text"><strong>* </strong></span>Address Line 1
 						</template>
+				</v-text-field>
+			</v-col>
+		</v-row>
+		<v-row>
+			<v-col cols="12" sm="12" md="12">
+				<v-text-field
+					v-model="lineAddress2"
+					v-show="homeAddressAvailable"
+					prepend-icon="mdi-menu-right"
+					label="Address Line 2">
 				</v-text-field>
 			</v-col>
 		</v-row>
@@ -125,7 +134,8 @@ import EventBus from '../eventBus'
 		'WA', 'WV', 'WI', 'WY',
 		],
 			country: ['USA'],
-			lineAddress: '',
+			lineAddress1: '',
+			lineAddress2: '',
 			cityAddress: '',
 			districtAddress: '',
 			stateAddress: '',
@@ -161,7 +171,8 @@ import EventBus from '../eventBus'
 		sendHomeAddressInfoToReviewPage()
 		{
 		const homeAddressPayload = {
-			lineAddress: this.lineAddress,
+			lineAddress1: this.lineAddress1,
+			lineAddress2: this.lineAddress2,
 			cityAddress: this.cityAddress,
 			districtAddress: this.districtAddress,
 			stateAddress: this.stateAddress,
@@ -178,7 +189,7 @@ import EventBus from '../eventBus'
 			
 		if(this.homeAddressAvailable)
 		{	
-			if(this.lineAddress == "") 
+			if(this.lineAddress1 == "") 
 			{
 				message += " Address"
 				valid = false
@@ -253,7 +264,8 @@ import EventBus from '../eventBus'
 	HomeAddressAvailable()
     {
 	this.homeAddressAvailable = true
-	this.lineAddress=""
+	this.lineAddress1=""
+	this.lineAddress2=""
 	this.cityAddress=""
 	this.stateAddress=""
 	this.districtAddress=""
@@ -262,7 +274,8 @@ import EventBus from '../eventBus'
     HomeAddressNotAvailable()
     {
 	this.homeAddressAvailable = false
-	this.lineAddress="Not Available"
+	this.lineAddress1="Not Available"
+	this.lineAddress2="Not Available"
 	this.cityAddress="Not Available"
 	this.stateAddress="Not Available"
 	this.districtAddress="Not Available"

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -34,7 +34,10 @@
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}} {{dataHomeAddress.lineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}}</div>
+				<template v-if="dataHomeAddress.lineAddress2 != ''">
+					<div class="font-weight-regular">{{dataHomeAddress.lineAddress2}}</div>
+				</template>
 				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
 					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
 			</v-col>

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -34,6 +34,7 @@
 
 		<v-row>	
 			<v-col cols="12">
+				<div class="font-weight-medium">Address Type:  <span class="font-weight-regular">{{dataHomeAddress.addressType}}</span></div>
 				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}}</div>
 				<template v-if="dataHomeAddress.lineAddress2 != ''">
 					<div class="font-weight-regular">{{dataHomeAddress.lineAddress2}}</div>

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -28,15 +28,15 @@
 		</v-row>
 		<v-row>
 			<v-col cols="12" sm="6" md="3">
-				<div class="font-weight-medium primary--text">Home Address </div>
+				<div class="font-weight-medium primary--text">Address</div>
 			</v-col>
 		</v-row>
 
 		<v-row>	
 			<v-col cols="12">
-				<div class="font-weight-medium">Street Address:  <span class="font-weight-regular">{{dataHomeAddress.lineAddress}}</span></div>
-				<div class="font-weight-medium">City, County, State, Country, Zip Code:  <span class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
-					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</span></div>
+				<div class="font-weight-regular">{{dataHomeAddress.lineAddress1}} {{dataHomeAddress.lineAddress2}}</div>
+				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
+					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
 			</v-col>
 		</v-row>
 

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -38,8 +38,8 @@
 				<template v-if="dataHomeAddress.lineAddress2 != ''">
 					<div class="font-weight-regular">{{dataHomeAddress.lineAddress2}}</div>
 				</template>
-				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, 
-					{{dataHomeAddress.districtAddress}}, {{dataHomeAddress.stateAddress}}, {{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
+				<div class="font-weight-regular">{{dataHomeAddress.cityAddress}}, {{dataHomeAddress.stateAddress}}, 
+					{{dataHomeAddress.countryAddress}}, {{dataHomeAddress.postalCode}}</div>
 			</v-col>
 		</v-row>
 


### PR DESCRIPTION
## :flipper: [JIRA Sprint Card]
https://mass-immunization-system.atlassian.net/browse/MVS-466

## :newspaper: [Work Description]
Made the following changes to the single patient home address page and the household home address page:
- Removed the “I have/do not have a home address” radio buttons and associated show/hide logic.
- Added an “Address Type” dropdown field with the options of “Home,” "Business," and “Temporary.”  
- Made “Address Type” required and included it in the page validation (verifyFormContents function).
Made the following changes to the single patient review and submit page and household review and submit page:
- Added the display of “Address Type”
- Removed the headings for street address, city, zip code, country (those are obvious)

## :vertical_traffic_light: [Testing/QA Notes]
- Build and load the application
- Complete the single patient registration process, specifically paying attention to the "Enter your address" and "Review and submit" pages to verify the following:  "Address Type" is required, the Address Type selections are Home, Business, and Work; the Address Type is displayed on the "Review and submit" page.
- Complete the household registration process, specifically paying attention to the "Enter your household address" and "Review and submit" pages to verify the following:  "Address Type" is required, the Address Type selections are Home, Business, and Work; the Address Type is displayed on the "Review and submit" page.
