### PR TITLE
[MVS-527] Provide dropdown list of suffix options on Personal Info page in PatRegApp

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_1.vue
@@ -33,10 +33,12 @@
       </v-col>
       <!-- Suffix -->
       <v-col cols="12" sm="6" md="6" lg="1">
-        <v-text-field 
-          label="Suffix" 
-          v-model="suffix">
-        </v-text-field>
+        <v-select
+        :items="suffixOptions"
+        id="suffix"
+        label="Suffix"
+        v-model="suffix">
+        </v-select>
       </v-col>
       <v-col cols="12" sm="12" md="12" lg="12">
         <v-checkbox
@@ -141,6 +143,7 @@ import EventBus from "../eventBus";
 export default {
   data() {
     return {
+      suffixOptions: ["II", "III", "IV", "Jr", "Sr"],
       genderIdOptions: ["Male", "Female", "Other", "Decline to answer"],
       raceOptions: [
         "Black or African American",

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
@@ -33,10 +33,12 @@
       </v-col>
       <!-- Suffix -->
       <v-col cols="12" sm="6" md="6" lg="1">
-        <v-text-field 
-          label="Suffix" 
-          v-model="suffix">
-        </v-text-field>
+        <v-select
+        :items="suffixOptions"
+        id="suffix"
+        label="Suffix"
+        v-model="suffix">
+        </v-select>
       </v-col>
     </v-row>
     <v-row align="center" justify="start">
@@ -163,6 +165,7 @@ import EventBus from "../eventBus";
 export default {
   data() {
     return {
+      suffixOptions: ["II", "III", "IV", "Jr", "Sr"],
       genderIdOptions: ["Male", "Female", "Other", "Decline to answer"],
       raceOptions: [
         "Black or African American",

--- a/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientPersonalInfo.vue
@@ -33,13 +33,13 @@
       </v-col>
       <!-- Suffix -->
       <v-col cols="12" sm="6" md="6" lg="1">
-        <v-text-field 
-          label="Suffix" 
-          id="suffix" 
-          v-model="suffix">
-        </v-text-field>
-      </v-col>
-    </v-row>
+      <v-select
+        :items="suffixOptions"
+        id="suffix"
+        label="Suffix"
+        v-model="suffix">
+        </v-select>
+      </v-col></v-row>
     <v-row align="center" justify="start">
       <v-col cols="12" sm="6" md="6" lg="4">
         <!-- Date of Birth -->
@@ -136,6 +136,7 @@ import EventBus from "../eventBus";
 export default {
   data() {
     return {
+      suffixOptions: ["II", "III", "IV", "Jr", "Sr"],
       genderIdOptions: ["Male", "Female", "Other", "Decline to answer"],
       raceOptions: [
         "Black or African American",


### PR DESCRIPTION


## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-527

## :newspaper: [Work Description]

Change the Suffix field from a text field to a select menu. Add these options to the select menu: II, III, IV, Jr, Sr. 
Make sure you do so for the single patient personal info page, Household personal info1 page and household personal info_n page. 

## :vertical_traffic_light: [Testing/QA Notes]

- Run the Patient Registration app locally
- Go through the single patient and household work flow 
- Once you get to the Personal Info page, make sure that the suffix field is a select menu that provides the following options: II, III, IV, Jr, Sr
- Make sure that the select option can be viewed on the Review and Submit Page 