### PR TITLE
[MVS-556] Remove business option from address type drop down menu

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/HouseholdHomeAddress.vue
@@ -121,7 +121,7 @@ import EventBus from '../eventBus'
 				'TX', 'UT', 'VT', 'VI', 'VA',
 				'WA', 'WV', 'WI', 'WY',
 				],
-			addressTypeOptions: ["Home", "Business", "Temporary"],
+			addressTypeOptions: ["Home", "Temporary"],
 			countryOptions: ['USA'],
 			addressType: '',
 			lineAddress1: '',

--- a/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientHomeAddress.vue
@@ -120,7 +120,7 @@ import EventBus from '../eventBus'
 				'TX', 'UT', 'VT', 'VI', 'VA',
 				'WA', 'WV', 'WI', 'WY',
 				],
-			addressTypeOptions: ["Home", "Business", "Temporary"],
+			addressTypeOptions: ["Home", "Temporary"],
 			countryOptions: ['USA'],
 			addressType: '',
 			lineAddress1: '',


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-556

## :newspaper: [Work Description]

Remove "Business" as an option for Address Type drop down menu. Per discussion with Waukesha County, we need to remove the “Business” option, as it may complicate the patient match-up in the WIR system.

## :vertical_traffic_light: [Testing/QA Notes]

- Run the Patient Registration app locally 
- Go through the single patient work flow 
- When the "Enter your address" page is reached, click on the Address type drop down menu 
- make sure that the only options displayed are: Home, Temporary
- Make sure the Business option is not there anymore 
- Go through the same steps but taking the household work flow instead
