### PR TITLE
MVS-513 Fix member card sizing on household review

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -63,7 +63,7 @@
 					<v-card class="pa-2" flat min-width=33%>
 						<v-img 
 							contain		
-							max-height="300"
+							height="300"
 							max-width="300" 
 							:src="dataHouseholdPersonalInfo[0] ? dataHouseholdPersonalInfo[0].patientPhotoSrc : undefined"
 							v-bind:class="{ hidden: 
@@ -94,7 +94,7 @@
 						:key="index">
 							<v-img
 								contain		
-								max-height="300"
+								height="300"
 								max-width="300" 
 								:src="dataHouseholdPersonalInfo[index] ? dataHouseholdPersonalInfo[index].patientPhotoSrc : undefined"
 								v-bind:class="{ hidden: 


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-513

## :newspaper: [Work Description]

Updated the HouseholdReviewSubmit page to render all of the household member images with a height of 300 pixels (previously, the "max-height" was 300).  Also adjusted the parent v-card attribute to align elements to the bottom.

## :vertical_traffic_light: [Testing/QA Notes]

Register a household of ~5+ members and upload a variety of images with different aspect ratios.  
For one or a few of the household members, do not upload a photo.
Verify that the "Personal Info:  Household Member #n" labels are horizontally aligned, regardless of the photo aspect ratio and whether or not a photo has been uploaded.  
Example:
![image](https://user-images.githubusercontent.com/61951196/104821619-cdbfa580-5802-11eb-87fa-a79bf913494a.png)

