### PR TITLE
MVS-607 Combine patient discharge with the submission of the vaccination record

### DIFF
--- a/PointOfDispensingApp/src/components/PatientDischargeComponent.vue
+++ b/PointOfDispensingApp/src/components/PatientDischargeComponent.vue
@@ -85,8 +85,6 @@
 </template>
 
 <script>
-import brokerRequests from "../brokerRequests";
-
 export default {
   name: "PatientDischargeComponent",
   computed: {

--- a/PointOfDispensingApp/src/components/PatientDischargeComponent.vue
+++ b/PointOfDispensingApp/src/components/PatientDischargeComponent.vue
@@ -30,7 +30,7 @@
         ></v-text-field>
       </v-col>
     </v-row>
-    <v-row>
+    <!--v-row>
       <v-col cols="2">
       </v-col>    
       <v-col cols="6">
@@ -38,7 +38,7 @@
           End encounter
         </v-btn>
       </v-col>
-    </v-row>
+    </v-row-->
     <v-row>
       <v-col cols="12">
         <v-divider></v-divider>
@@ -86,15 +86,7 @@
     },
     methods: 
     {
-      endEncounter() {
-        //the following is sending dummy data until we have the API in place
-        const encounterResourcePayload = {
-          encounterStatus:'Finished',
-          encounterTimeStamp: new Date().toISOString(),
-        }
-        //send data to Vuex
-        this.$store.dispatch('patientDischarged', encounterResourcePayload)
-      }
+      
     },
     components: 
     {

--- a/PointOfDispensingApp/src/components/VaccinationCanceledComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationCanceledComponent.vue
@@ -102,6 +102,9 @@ export default {
         //send data to Vuex
         this.$store.dispatch("vaccinationCanceled", vaccinationCanceledPlayload);
 
+        //Advance to the Discharge page
+        this.$router.push("Discharge");
+
         //Close the dialog
         this.dialog = false;
     },
@@ -131,6 +134,7 @@ export default {
         alert("Discharge not successful");
       }
     });
+  },
   },
   components: {},
   data() {

--- a/PointOfDispensingApp/src/components/VaccinationCanceledComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationCanceledComponent.vue
@@ -53,7 +53,7 @@
     </v-row>
     <v-row align="center" justify="center">
       <v-col cols="6">
-        <v-btn block color="accent" @click="submitVaccinationRecord()">
+        <v-btn block color="accent" @click="submitVaccinationRecord(); endEncounter();">
           Submit vaccination record
         </v-btn>
       </v-col>
@@ -94,6 +94,14 @@
 
         //Close the dialog
         this.dialog = false;
+      },
+      endEncounter() {
+        const encounterResourcePayload = {
+          encounterStatus:'Finished',
+          encounterTimeStamp: new Date().toISOString(),
+        }
+        //send data to Vuex
+        this.$store.dispatch('patientDischarged', encounterResourcePayload)
       }
     },
     components: 

--- a/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
@@ -192,7 +192,7 @@
                 <v-btn	
                   color="primary"
                   text
-                  @click="submitVaccinationRecord()">
+                  @click="submitVaccinationRecord(); endEncounter();">
                   Submit
                 </v-btn>
               </v-card-actions>
@@ -243,6 +243,14 @@
 
         //Close the dialog
         this.dialog = false;
+      },
+      endEncounter() {
+        const encounterResourcePayload = {
+          encounterStatus:'Finished',
+          encounterTimeStamp: new Date().toISOString(),
+        }
+        //send data to Vuex
+        this.$store.dispatch('patientDischarged', encounterResourcePayload)
       }
     },
     components: 


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-607

## :newspaper: [Work Description]

Updated VaccinationProceedComponent and VaccinationCanceledComponent to call submitVaccinationRecord as well as endEncounter upon clicking on the "Submit Vaccination Record" button.  The page auto-advances to the discharge page and shows the vaccination status + timestamp as well as the encounter status + timestamp.

## :vertical_traffic_light: [Testing/QA Notes]

Retrieve a patient record and complete check-in.
On the Vaccination Event page, complete the screening questions and decide to proceed with vaccination ("Yes" radio button)
Submit the vaccination record
Verify that the UI auto-advances to the Discharge page.
Verify that the vaccination status is "Completed"
Verify that the discharge status is "Finished"
Verify that the time stamps for the vaccination status and discharge status are the same.

Retrieve a patient record and complete check-in.
On the Vaccination Event page, complete the screening questions and decide not to proceed with vaccination ("No" radio button)
Submit the vaccination record
Verify that the UI auto-advances to the Discharge page.
Verify that the vaccination status is "Not-done"
Verify that the discharge status is "Finished"
Verify that the time stamps for the vaccination status and discharge status are the same.