### PR TITLE
MVS-557 "Vaccination Status" and associated "Date/Time" are not necessary in VaccinationProceedComponent.vue

### DIFF
--- a/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
@@ -185,12 +185,6 @@
   export default {
     name: 'VaccinationProceedComponent',
     computed: {
-      immunizationStatus() {
-        return this.$store.state.immunizationResource.immunizationStatus
-      },
-      immunizationTimeStamp() {
-        return this.$store.state.immunizationResource.immunizationTimeStamp
-      },
       healthcarePractitioner() {
         return this.$store.state.immunizationResource.healthcarePractitioner
       },

--- a/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
+++ b/PointOfDispensingApp/src/components/VaccinationProceedComponent.vue
@@ -87,29 +87,14 @@
       <p> </p> <!--blank row for spacing-->
     </v-row>
     <v-row>
-      <v-col cols="12">
-        <v-btn color="accent">
-          Vaccine administered
-        </v-btn>
-      </v-col>
-    </v-row>
-    <v-row>
       <v-col cols="5">
         <v-row no-gutters>
-          <v-col cols="4">
-            <div class="secondary--text">Vaccination Status</div>
-          </v-col>
-          <v-col cols="8">
-            <v-text-field outlined dense filled readonly
-              :value=immunizationStatus
-            ></v-text-field>
-          </v-col>
           <v-col cols="4">
             <div class="secondary--text">Healthcare Practitioner</div>
           </v-col>
           <v-col cols="8">
             <v-text-field outlined dense filled readonly
-              :value=healthcarePractitioner 
+              :value=healthcarePractitioner
             ></v-text-field>
           </v-col>
           <v-col cols="4">
@@ -125,14 +110,6 @@
               v-model="site"
             ></v-select>
           </v-col>
-          <v-col cols="4">
-            <div class="secondary--text">Route</div>
-          </v-col>
-          <v-col cols="8">
-            <v-text-field outlined dense filled readonly
-              :value=route
-            ></v-text-field>
-          </v-col>
         </v-row>
       </v-col>
       <!--blank column for spacing-->
@@ -141,11 +118,11 @@
       <v-col cols="5">
         <v-row no-gutters>
           <v-col cols="4">
-            <div class="secondary--text">Date/Time</div>
+            <div class="secondary--text">Route</div>
           </v-col>
           <v-col cols="8">
             <v-text-field outlined dense filled readonly
-              :value=immunizationTimeStamp
+              :value=route
             ></v-text-field>
           </v-col>
         </v-row>


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-557

## :newspaper: [Work Description]

Updated VaccinationProceedComponent to remove the unnecessary/redundant vaccination status and time stamp fields. 

## :vertical_traffic_light: [Testing/QA Notes]

Retrieve a patient record and check the patient in.
On the Vaccination Event page, complete the screening questions and decide to proceed with the vaccination ("Yes" radio button)
Verify that the content below the screening questions looks like this:
![image](https://user-images.githubusercontent.com/61951196/104826212-6283cc80-581e-11eb-8e23-0c3f67cbfd4e.png)

