### PR TITLE
Mvs-535 update pat reg to include emergency contact relationship type

### DIFF
--- a/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
@@ -56,7 +56,7 @@
 				<v-select
 					v-model="emergencyContactRelationship"
 					:items="relationshipOptions"
-					label="Relationship"
+					label="Relationship: this person is your"
 					prepend-icon="mdi-blank">
 				</v-select>
 			</v-col>

--- a/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/HouseholdEmergencyContact.vue
@@ -50,6 +50,17 @@
         ></v-select>
       </v-col>
     </v-row>
+    <v-row align="center" justify="start">
+			<!-- Relationship Type -->
+			<v-col cols="12" sm="6" md="6" lg="4">
+				<v-select
+					v-model="emergencyContactRelationship"
+					:items="relationshipOptions"
+					label="Relationship"
+					prepend-icon="mdi-blank">
+				</v-select>
+			</v-col>
+		</v-row>
 	</v-container>
 </template>
 
@@ -60,10 +71,12 @@ export default {
   data() {
     return {
       phoneTypeOptions: ["Home", "Mobile", "Work"],
+      relationshipOptions: ["Spouse", "Parent", "Guardian", "Care Giver", "Sibling", "Grandparent", "Child", "Foster Child", "Stepchild", "Other"],
       emergencyContactFamilyName: '',
       emergencyContactGivenName: '',
       emergencyContactPhoneNumber: '',
-      emergencyContactPhoneNumberType: ''
+      emergencyContactPhoneNumberType: '',
+      emergencyContactRelationship: ''
     };
   },
   methods: {
@@ -72,7 +85,8 @@ export default {
         emergencyContactFamilyName: this.emergencyContactFamilyName,
         emergencyContactGivenName: this.emergencyContactGivenName,
         emergencyContactPhoneNumber: this.emergencyContactPhoneNumber,
-        emergencyContactPhoneNumberType: this.emergencyContactPhoneNumberType
+        emergencyContactPhoneNumberType: this.emergencyContactPhoneNumberType,
+        emergencyContactRelationship: this.emergencyContactRelationship
       }
       EventBus.$emit('DATA_HOUSEHOLD_EMERGENCY_CONTACT_INFO_PUBLISHED', householdEmergencyContactPayload)
     },

--- a/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
+++ b/PatientRegistrationApp/src/components/HouseholdPersonalInfo_n.vue
@@ -237,6 +237,7 @@ export default {
         patientPhotoSrc: (this.patientPhoto && this.patientPhoto.size) ? URL.createObjectURL( this.patientPhoto ) : undefined,
         race: this.race,
         ethnicity: this.ethnicity,
+        relationship: this.relationship
       };
       EventBus.$emit(
         "DATA_HOUSEHOLD_PERSONAL_INFO_PUBLISHED",

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -79,7 +79,10 @@
 						<div class="font-weight-medium">Preferred Language:  <span class="font-weight-regular">{{dataHouseholdPersonalInfo[0].preferredLanguage}}</span></div>
 						<div class="font-weight-light">Emergency Contact</div>
 						<div class="font-weight-medium">Name:  <span class="font-weight-regular">{{dataHouseholdEmergencyContact.emergencyContactFamilyName}}, 
-						{{dataHouseholdEmergencyContact.emergencyContactGivenName}}</span></div>
+						{{dataHouseholdEmergencyContact.emergencyContactGivenName}}
+							<span v-if="dataHouseholdEmergencyContact.emergencyContactRelationship != ''">
+							(Relationship: {{dataHouseholdEmergencyContact.emergencyContactRelationship}})</span>
+							</span></div>
 						<div class="font-weight-medium">Phone:  <span class="font-weight-regular">{{dataHouseholdEmergencyContact.emergencyContactPhoneNumber}} 
 						<span v-if="dataHouseholdEmergencyContact.emergencyContactPhoneNumberType != ''">({{dataHouseholdEmergencyContact.emergencyContactPhoneNumberType}})</span></span></div>
 						<v-card-actions>
@@ -110,7 +113,7 @@
 							<div class="font-weight-medium">Preferred Language:  <span class="font-weight-regular">{{dataHouseholdPersonalInfo[index].preferredLanguage}}</span></div>
 							<div class="font-weight-light">Emergency Contact</div>
 							<div class="font-weight-medium">Name:  <span class="font-weight-regular">{{dataHouseholdPersonalInfo[0].familyName}}, 
-							{{dataHouseholdPersonalInfo[0].givenName}}</span></div>
+							{{dataHouseholdPersonalInfo[0].givenName}} (Relationship: {{dataHouseholdPersonalInfo[index].relationship}})</span></div>
 							<div class="font-weight-medium">Phone:  <span class="font-weight-regular">{{dataHouseholdContactInfo.primaryPhoneNumber}} 
 							<span v-if="dataHouseholdContactInfo.primaryPhoneNumberType != ''">({{dataHouseholdContactInfo.primaryPhoneNumberType}})</span></span></div>
 							<v-card-actions>

--- a/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
@@ -56,7 +56,7 @@
 				<v-select
 					v-model="emergencyContactRelationship"
 					:items="relationshipOptions"
-					label="Relationship"
+					label="Relationship: this person is your"
 					prepend-icon="mdi-blank">
 				</v-select>
 			</v-col>

--- a/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientEmergencyContact.vue
@@ -50,6 +50,17 @@
 				></v-select>
 			</v-col>
 		</v-row>
+		<v-row align="center" justify="start">
+			<!-- Relationship Type -->
+			<v-col cols="12" sm="6" md="6" lg="4">
+				<v-select
+					v-model="emergencyContactRelationship"
+					:items="relationshipOptions"
+					label="Relationship"
+					prepend-icon="mdi-blank">
+				</v-select>
+			</v-col>
+		</v-row>
 	</v-container>
 </template>
 
@@ -60,11 +71,13 @@ export default {
   name: "SinglePatientEmergencyContact",
   data() {
     return {
-      phoneTypeOptions: ["Home", "Mobile", "Work"],
-      emergencyContactFamilyName: '',
-      emergencyContactGivenName: '',
-      emergencyContactPhoneNumber: '',
-      emergencyContactPhoneNumberType: ''
+		phoneTypeOptions: ["Home", "Mobile", "Work"],
+		relationshipOptions: ["Spouse", "Parent", "Guardian", "Care Giver", "Sibling", "Grandparent", "Child", "Foster Child", "Stepchild", "Other"],
+		emergencyContactFamilyName: '',
+		emergencyContactGivenName: '',
+		emergencyContactPhoneNumber: '',
+		emergencyContactPhoneNumberType: '',
+		emergencyContactRelationship: ''
     };
   },
   methods: {
@@ -73,7 +86,8 @@ export default {
         emergencyContactFamilyName: this.emergencyContactFamilyName,
         emergencyContactGivenName: this.emergencyContactGivenName,
         emergencyContactPhoneNumber: this.emergencyContactPhoneNumber,
-        emergencyContactPhoneNumberType: this.emergencyContactPhoneNumberType
+		emergencyContactPhoneNumberType: this.emergencyContactPhoneNumberType,
+		emergencyContactRelationship: this.emergencyContactRelationship
       }
       EventBus.$emit('DATA_EMERGENCY_CONTACT_INFO_PUBLISHED', emergencyContactPayload)
     },

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -78,7 +78,9 @@
 		<v-row>	
 			<v-col cols="12">
 				<div class="font-weight-medium">Name:  <span class="font-weight-regular">{{dataEmergencyContact.emergencyContactFamilyName}}, 
-					{{dataEmergencyContact.emergencyContactGivenName}}</span></div>
+					{{dataEmergencyContact.emergencyContactGivenName}}
+					<span v-if="dataEmergencyContact.emergencyContactRelationship != ''">(Relationship: {{dataEmergencyContact.emergencyContactRelationship}})</span>
+					</span></div>
 				<div class="font-weight-medium">Phone:  <span class="font-weight-regular">{{dataEmergencyContact.emergencyContactPhoneNumber}} 
 					<span v-if="dataEmergencyContact.emergencyContactPhoneNumberType != ''">({{dataEmergencyContact.emergencyContactPhoneNumberType}})</span></span></div>
 			</v-col>


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-535

## :newspaper: [Work Description]

Updated the single patient and household registration "emergency contact" pages to capture the relationship (as an optional field).  Updated the "review and submit" pages to also show the relationship.

## :vertical_traffic_light: [Testing/QA Notes]

- Build and load the patient registration app
- Choose the single patient registration
- On the "emergency contact" page, verify that there is an optional field to select the emergency contact relationship type
- Proceed to the "review and submit" page
- Verify that the relationship type you configured on the "emergency contact" page is presented with the emergency contact name
- Alternative workflow:  Complete the steps above without selecting an emergency contact relationship.  Verify that the emergency contact relationship is not displayed on the "review and submit" page.
- Reload the application
- Choose the household registration
- On the "emergency contact" page, verify that there is an optional field to select the emergency contact relationship type
- Proceed to the "review and submit" page
- Verify that the relationship type you configured on the "emergency contact" page is presented with the emergency contact name
- Verify that the relationship type(s) you configured for household members #2-#n are also presented with the emergency contact name (Note:  further work will be done here under MVS-559)
- Alternative workflow:  Complete the steps above without selecting an emergency contact relationship.  Verify that the emergency contact relationship is not displayed on the "review and submit" page.

