### PR TITLE
MVS-687 Hide "Configuration" menu item in the POD app

### DIFF
--- a/PointOfDispensingApp/src/App.vue
+++ b/PointOfDispensingApp/src/App.vue
@@ -84,7 +84,7 @@
               <v-list-item-title class="font-weight-medium">Adverse Reaction</v-list-item-title>
             </v-list-item-content>
           </v-list-item-->
-          <!-- Configuration -->
+          <!-- SAVE FOR FUTURE:  Configuration>
           <v-list-item :disabled="isConfigurationPageDisabled" router :to="'/Configuration'">
             <v-list-item-action>
               <v-icon large>mdi-cog</v-icon>
@@ -92,7 +92,7 @@
             <v-list-item-content>
               <v-list-item-title class="font-weight-medium">Configuration</v-list-item-title>
             </v-list-item-content>
-          </v-list-item>
+          </v-list-item-->
         </v-list-item-group>
       </v-list>
     </v-navigation-drawer>


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-687

## :newspaper: [Work Description]

Updated App.vue in the PointOfDispensingApp to comment out the code that displays the "Configuration" menu item.

## :vertical_traffic_light: [Testing/QA Notes]

Build and load the POD application using any of the means described in README.md.
Verify that there is no "Configuration" left menu item displayed.
