### PR TITLE
Fix: Send patient contact info

### DIFF
--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -223,14 +223,14 @@ export default {
       };
 
       patient.phone = [];
-      if (this.dataContactInfo.primaryPhoneNumber)
+      if (this.dataContactInfo.patientPhoneNumber)
         patient.phone.push({
-          value: this.dataContactInfo.primaryPhoneNumber,
-          use: this.dataContactInfo.primaryPhoneNumberType,
+          value: this.dataContactInfo.patientPhoneNumber,
+          use: this.dataContactInfo.patientPhoneNumberType,
         });
       patient.email = [];
-      if (this.dataContactInfo.primaryEmail)
-        patient.email.push(this.dataContactInfo.primaryEmail);
+      if (this.dataContactInfo.patientEmail)
+        patient.email.push(this.dataContactInfo.patientEmail);
 
       patient.contact = {
         family: this.dataEmergencyContact.emergencyContactFamilyName,


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-696

## :newspaper: [Work Description]

The incorrect property name was being referenced, so the patient contact info was not being sent to the broker

## :vertical_traffic_light: [Testing/QA Notes]

Repeat for single and household workflows 

- Register at least one user through the registration app
- After submitting the data, there should be a qr value in the browser console. Go to localhost:3000/Patient/_QR-VALUE_, which will show the FHIR resource id.
- Lookup the patient through the FHIR server, at localhost:8080/hapi-fhir-jpaserver/fhir/Patient/_RESOURCE-ID_
- Verify the resource has the telecom field populated (note: different from contact.telecom, which should also exist).
For household registration, only the first patient (the head of the household) should have contact info