### PR TITLE
Mvs 728 add in progress indicator while submitting patient record to backend

### DIFF
--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -139,7 +139,9 @@
                           @singlePatientRegistrationSuccess="
                             SinglePatientRegistrationSuccessful
                           "
-                          @singlePatientRegistrationFail="SinglePatientRegistrationFailed"
+                          @singlePatientRegistrationFail="
+                          SinglePatientRegistrationFailed
+                          "
                       /></v-card>
                     </v-stepper-content>
 
@@ -274,6 +276,9 @@
                           "
                           @householdRegistrationSuccess="
                             householdRegistrationSuccessful
+                          "
+                          @householdRegistrationFail="
+                            householdRegistrationFailed
                           "
                       /></v-card>
                     </v-stepper-content>
@@ -443,6 +448,7 @@
                           color="primary"
                           text
                           @click="submitHouseholdRegistration()"
+                          :loading="loading"
                         >
                           Yes
                         </v-btn>
@@ -525,15 +531,20 @@ export default {
       this._data.loading=false;
     },
     submitHouseholdRegistration() {
+      this._data.loading=true;
       this.$refs.householdReviewSubmit.submitPatientInfo();
     },
     householdRegistrationSuccessful(data) {
+      this._data.loading=false;
       this.$refs.householdFollowUp.updateQrCodeData(data);
       this.goToPage(
         config.registrationPages.HOUSEHOLD_FOLLOWUP_PAGE +
           this.getNumberOfHouseholdMembers() -
           2
       );
+    },
+    householdRegistrationFailed(){
+      this._data.loading=false;
     },
     goToPage(pageNum) {
       this.page = pageNum;

--- a/PatientRegistrationApp/src/App.vue
+++ b/PatientRegistrationApp/src/App.vue
@@ -139,6 +139,7 @@
                           @singlePatientRegistrationSuccess="
                             SinglePatientRegistrationSuccessful
                           "
+                          @singlePatientRegistrationFail="SinglePatientRegistrationFailed"
                       /></v-card>
                     </v-stepper-content>
 
@@ -370,6 +371,7 @@
                           color="primary"
                           text
                           @click="submitSinglePatientRegistration()"
+                          :loading="loading"
                         >
                           Yes
                         </v-btn>
@@ -511,11 +513,16 @@ export default {
   name: "App",
   methods: {
     submitSinglePatientRegistration() {
+      this._data.loading=true;
       this.$refs.singlePatientReviewSubmit.submitPatientInfo();
     },
     SinglePatientRegistrationSuccessful(data) {
+      this._data.loading=false;
       this.$refs.singlePatientFollowUp.updateQrCodeData(data);
       this.goToPage(config.registrationPages.SINGLE_PATIENT_FOLLOWUP_PAGE);
+    },
+    SinglePatientRegistrationFailed() {
+      this._data.loading=false;
     },
     submitHouseholdRegistration() {
       this.$refs.householdReviewSubmit.submitPatientInfo();
@@ -885,6 +892,7 @@ export default {
       registrationPath: config.selectedRegistrationPath.NO_PATH_SELECTED,
       numberOfHouseholdMembers: 2,
       familyName: "",
+      loading: false
     };
   },
 };

--- a/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/HouseholdReviewSubmit.vue
@@ -348,6 +348,7 @@ export default {
         } else if (response.error) {
           console.log(response.error);
           alert("Registration not successful");
+          this.$emit("householdRegistrationFail");
         }
       });
     },

--- a/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
+++ b/PatientRegistrationApp/src/components/SinglePatientReviewSubmit.vue
@@ -264,6 +264,7 @@ export default {
         } else if (response.error) {
           console.log(response.error);
           alert("Registration not successful");
+          this.$emit("singlePatientRegistrationFail");
         }
       });
     },


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-728

## :newspaper: [Work Description]

This PR adds "in progress" indicator upon attempting to submit patient registration info

## :vertical_traffic_light: [Testing/QA Notes]

Cases where there should be a spinner:
At the Patient Registration- final review page "Are you sure?" pop-up>click "Yes" point, there will be a spinner until the submit process either succeeds or fails. 
- This needed to be added both for the single person "Register myself" workflow and for the "Register my household" workflow.
- To slow down the submit process, I used a tool called Clumsy (see below for settings) but you can use your favorite way to simulate lag if needed (such as Clumsy settings Throttle, Timeframe<= 100 ms, on for inbound/outbound, and Chance=100% -> will still likely succeed)
- To create a fail condition, like one due to a bad network connection, I set Clumsy to the following settings:
![image](https://user-images.githubusercontent.com/77426209/111884888-6ce35380-8992-11eb-930f-73a6369c589d.png)
You can download Clumsy here https://jagt.github.io/clumsy/download.html
(Using Clumsy is optional - feel free to use your favorite fail condition if you have one)

