### PR TITLE
[MVS-729] add a default value for dose quantity

### DIFF
--- a/PointOfDispensingApp/src/store/store.js
+++ b/PointOfDispensingApp/src/store/store.js
@@ -113,6 +113,8 @@ export default new Vuex.Store({
             state.encounterResource = {};
             state.appointmentResource = {};
             state.immunizationResource = {};
+            //set the default dose quantity to 0.5 mL
+            state.immunizationResource.doseQuantity = '0.5 mL';
             
             state.screeningResponses.vaccinationDecision = '',
             state.screeningResponses.screeningQ1 = '',
@@ -177,6 +179,8 @@ export default new Vuex.Store({
 
             //reset the Immunization resource (e.g. for the 2nd dose):
             state.immunizationResource = {};
+            //set the default dose quantity to 0.5 mL
+            state.immunizationResource.doseQuantity = '0.5 mL';
             //reset the screening questions (e.g. for the 2nd dose):
             state.screeningResponses = {};
         },


### PR DESCRIPTION
## :floppy_disk: [Code Check]
_Make sure you've checked/done the following before making this PR!_
* Does your code build/run?
* Does your design approach make sense?
* Does your work achieve the intention of the card?
* Does your code have any unintentional side effects -- have you tested a full workflow & checked the logic branches you touched?
* Did you make a unit test for your code (as appropriate)?
* Is your branch relatively up to date with the Development branch (within ~2 commits)
* Have you moved the card to "Needs QA" in Jira


## :flipper: [JIRA Sprint Card]

https://mass-immunization-system.atlassian.net/browse/MVS-729

## :newspaper: [Work Description]

We can save the user a couple of clicks if we just auto-select the 0.5 mL option for the “Dose Quantity” field. This card sets the 0.5 mL quantity as a default in the POD app

## :vertical_traffic_light: [Testing/QA Notes]

- Run the POD app
- Go through the check in process and proceed to the VaccinationProceedComponent page
- Make sure that the Dose Quantity field is defaulted on 0.5 mL
- Make sure you can still switch between the other options
